### PR TITLE
Fixes the LOB creation exception on startup.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          lob:
+            non_contextual_creation: true


### PR DESCRIPTION
Hibernate tries to detect whether some JDBC features work or not in
the database driver. This one causes an exception that is too low
level for Spring to catch, and it bubbles up into the logs with a
truly gigantic stack trace. By adding an application YAML with this
very deeply buried parameter we can tell Hibernate not to test that
feature, which prevents the stack trace from appearing.

Figured out what to do from reading spring-projects/spring-boot#12007