### PR TITLE
Fix some edge cases in the tokenizer.

### DIFF
--- a/src/main/java/com/agonyengine/resource/InputTokenizer.java
+++ b/src/main/java/com/agonyengine/resource/InputTokenizer.java
@@ -24,6 +24,13 @@ public class InputTokenizer {
             if (isQuoting || Character.isAlphabetic(codepoint) || Character.isDigit(codepoint)) {
                 if (curChar == '"') {
                     isQuoting = false;
+
+                    String token = buf.toString().trim();
+
+                    if (token.length() > 0) {
+                        tokens.add(token);
+                        buf.setLength(0);
+                    }
                 } else {
                     if (!isQuoting) {
                         buf.append(Character.toUpperCase(curChar));
@@ -50,6 +57,13 @@ public class InputTokenizer {
                 buf.setLength(0);
             } else if (curChar == '"') {
                 isQuoting = true;
+
+                String token = buf.toString().trim();
+
+                if (token.length() > 0) {
+                    tokens.add(token);
+                    buf.setLength(0);
+                }
             }
         }
 
@@ -57,6 +71,9 @@ public class InputTokenizer {
 
         if (token.length() > 0) {
             tokens.add(token);
+        }
+
+        if (tokens.size() > 0) {
             tokenList.add(tokens.toArray(new String[tokens.size()]));
         }
 

--- a/src/test/java/com/agonyengine/resource/InputTokenizerTest.java
+++ b/src/test/java/com/agonyengine/resource/InputTokenizerTest.java
@@ -83,6 +83,16 @@ public class InputTokenizerTest {
     }
 
     @Test
+    public void testEmptyQuotedString() {
+        List<String[]> tokens = inputTokenizer.tokenize("empty \"\" quote");
+
+        assertEquals(1, tokens.size());
+        assertEquals(2, tokens.get(0).length);
+        assertEquals("EMPTY", tokens.get(0)[0]);
+        assertEquals("QUOTE", tokens.get(0)[1]);
+    }
+
+    @Test
     public void testPeriods() {
         List<String[]> tokens = inputTokenizer.tokenize("this is. two sentences");
 
@@ -138,5 +148,18 @@ public class InputTokenizerTest {
         assertEquals(1, tokens.size());
         assertEquals(1, tokens.get(0).length);
         assertEquals("TEST", tokens.get(0)[0]);
+    }
+
+    @Test
+    public void testEmbeddedQuotes() {
+        List<String[]> tokens = inputTokenizer.tokenize("code: \"System.out.println(\"Test\");\" code");
+
+        assertEquals(1, tokens.size());
+        assertEquals(5, tokens.get(0).length);
+        assertEquals("CODE", tokens.get(0)[0]);
+        assertEquals("System.out.println(", tokens.get(0)[1]);
+        assertEquals("TEST", tokens.get(0)[2]);
+        assertEquals(");", tokens.get(0)[3]);
+        assertEquals("CODE", tokens.get(0)[4]);
     }
 }


### PR DESCRIPTION
* An empty quoted string would create a token with the empty string in it.
* Nested sets of quotes could create a token that was partially quoted and partially capitalized, when it should be broken into two tokens.