### PR TITLE
Basic framework for in-game maps.

### DIFF
--- a/src/main/java/com/agonyengine/config/ApplicationConfiguration.java
+++ b/src/main/java/com/agonyengine/config/ApplicationConfiguration.java
@@ -1,13 +1,18 @@
 package com.agonyengine.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.Date;
+import java.util.UUID;
 
 @Configuration
 public class ApplicationConfiguration {
     private Date bootDate = new Date();
+
+    @Value("${agonyengine.maps.default}")
+    private UUID defaultMapId;
 
     @Bean(name = "applicationVersion")
     public String applicationVersion() {
@@ -17,5 +22,10 @@ public class ApplicationConfiguration {
     @Bean(name = "applicationBootDate")
     public Date applicationBootDate() {
         return bootDate;
+    }
+
+    @Bean
+    public UUID defaultMapId() {
+        return defaultMapId;
     }
 }

--- a/src/main/java/com/agonyengine/model/actor/GameMap.java
+++ b/src/main/java/com/agonyengine/model/actor/GameMap.java
@@ -1,0 +1,82 @@
+package com.agonyengine.model.actor;
+
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.util.UUID;
+
+@Entity
+public class GameMap {
+    @Id
+    @GeneratedValue
+    @Type(type = "pg-uuid")
+    private UUID id;
+    private int width;
+    private byte[] tiles;
+
+    public GameMap() {}
+
+    public GameMap(int width, byte[] tiles) {
+        this.width = width;
+        this.tiles = tiles;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public byte[] getTiles() {
+        return tiles;
+    }
+
+    public void setTiles(byte[] tiles) {
+        this.tiles = tiles;
+    }
+
+    /*
+     * Maps are rectangles of {width} tiles on the X axis, where (0, 0) is the bottom left corner. So
+     * given the following map:
+     *
+     * 0x7 0x8 0x9 (2)
+     * 0x4 0x5 0x6 (1)
+     * 0x1 0x2 0x3 (0)
+     * (0) (1) (2)
+     *
+     * setTile(2, 1, 0x0)
+     *
+     * ...changes the map to:
+     *
+     * 0x7 0x8 0x9
+     * 0x4 0x5 0x0
+     * 0x1 0x2 0x3
+     *
+     * The following methods are meant to make it easy to deal with the map in terms of coordinates rather than
+     * having to deal directly with the byte array.
+     */
+
+    public byte getTile(int x, int y) {
+        return tiles[computeIndex(x, y)];
+    }
+
+    public void setTile(int x, int y, byte value) {
+        tiles[computeIndex(x, y)] = value;
+    }
+
+    private int computeIndex(int x, int y) {
+        return y * width + x;
+    }
+}

--- a/src/main/java/com/agonyengine/repository/GameMapRepository.java
+++ b/src/main/java/com/agonyengine/repository/GameMapRepository.java
@@ -1,0 +1,9 @@
+package com.agonyengine.repository;
+
+import com.agonyengine.model.actor.GameMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface GameMapRepository extends JpaRepository<GameMap, UUID> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+agonyengine:
+  maps:
+    default: "5231e20f-0658-4685-9396-6e69ebfb2c3b"
+
 spring:
   jpa:
     properties:

--- a/src/main/resources/db/migration/R__maps.sql
+++ b/src/main/resources/db/migration/R__maps.sql
@@ -1,0 +1,3 @@
+INSERT INTO game_map (id, width, tiles)
+VALUES ('5231e20f-0658-4685-9396-6e69ebfb2c3b', 3, decode('000000000000000000', 'hex')) ON CONFLICT (id) DO
+UPDATE SET width=EXCLUDED.width, tiles=EXCLUDED.tiles;

--- a/src/main/resources/db/migration/V0006__map_schema.sql
+++ b/src/main/resources/db/migration/V0006__map_schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE game_map (
+  id UUID NOT NULL,
+  width INTEGER NOT NULL,
+  tiles bytea NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/src/test/java/com/agonyengine/model/actor/GameMapTest.java
+++ b/src/test/java/com/agonyengine/model/actor/GameMapTest.java
@@ -1,0 +1,68 @@
+package com.agonyengine.model.actor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameMapTest {
+    private byte[] defaultMap = new byte[] {
+        0x07, 0x08, 0x09,
+        0x04, 0x05, 0x06,
+        0x01, 0x02, 0x03
+    };
+
+    private GameMap map;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        map = new GameMap(3, defaultMap);
+    }
+
+    @Test
+    public void testId() {
+        UUID id = UUID.randomUUID();
+
+        map.setId(id);
+
+        assertEquals(id, map.getId());
+    }
+
+    @Test
+    public void testWidth() {
+        assertEquals(3, map.getWidth());
+
+        map.setWidth(5);
+
+        assertEquals(5, map.getWidth());
+    }
+
+    @Test
+    public void testTiles() {
+        byte[] updatedMap = new byte[] {
+            0x10, 0x11, 0x12,
+            0x0D, 0x0E, 0x0F,
+            0x0A, 0x0B, 0x0C
+        };
+
+        assertEquals(defaultMap, map.getTiles());
+
+        map.setTiles(updatedMap);
+
+        assertEquals(updatedMap, map.getTiles());
+    }
+
+    @Test
+    public void testSetGetTile() {
+        assertEquals(0x05, map.getTile(1, 1));
+
+        map.setTile(1, 1, (byte)0x7F);
+
+        assertEquals((byte)0x7F, map.getTile(1, 1));
+    }
+}


### PR DESCRIPTION
GameMap is the basic unit for sections of the world. Each GameMap is a rectangle of arbitrary size, and each "room" (in the MUD sense) is represented as a byte within the GameMap's byte array. The value of the byte will eventually correspond to a tile in a tileset that tells us what that room is.

The really clever part here is that each GameMap is a single row in the database and will be primarily accessed by ID, which can be very fast. Each map will have "portals" to other maps which is how we'll build out a full sized world. It's also how we'll be able to handle containers and inventories. If you get picked up by someone you could find yourself in a single tile map representing their inventory. If you're really big and pick up a house, the house's map could break its link to whatever map it was originally on and now link to your inventory. I think we'll find this is a very flexible system that could eventually allow for vehicles, carrying other creatures, and a reasonable way to handle the fact that MUD rooms aren't all the same "size" the way roguelike tiles are.

I preloaded the database with a very boring "default" map which demonstrates two things. First, a way to preload the world with hard-coded content. That first map could be a MUD school newbie area or something like that. It's also a good testing ground for the next step, which is to add actors (aka. MOBs or NPCs and players).