### PR TITLE
Actors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.agonyengine'
-version '0.4.0-SNAPSHOT'
+version '0.5.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/agonyengine/model/actor/Actor.java
+++ b/src/main/java/com/agonyengine/model/actor/Actor.java
@@ -1,0 +1,109 @@
+package com.agonyengine.model.actor;
+
+import com.agonyengine.model.stomp.GameOutput;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+public class Actor {
+    @Id
+    @GeneratedValue
+    @Type(type = "pg-uuid")
+    private UUID id;
+
+    private String name;
+
+    private String sessionUsername;
+    private String sessionId;
+
+    @ManyToOne
+    private GameMap gameMap;
+    private Integer x;
+    private Integer y;
+
+    public GameOutput onChannel(Actor origin, String message) {
+        GameOutput output = new GameOutput();
+
+        output.append(String.format("[cyan]%s says '%s[cyan]'", origin.getName(), message));
+        output.append("");
+        output.append("> ");
+
+        return output;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSessionUsername() {
+        return sessionUsername;
+    }
+
+    public void setSessionUsername(String sessionUsername) {
+        this.sessionUsername = sessionUsername;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public GameMap getGameMap() {
+        return gameMap;
+    }
+
+    public void setGameMap(GameMap gameMap) {
+        this.gameMap = gameMap;
+    }
+
+    public Integer getX() {
+        return x;
+    }
+
+    public void setX(Integer x) {
+        this.x = x;
+    }
+
+    public Integer getY() {
+        return y;
+    }
+
+    public void setY(Integer y) {
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Actor)) return false;
+        Actor actor = (Actor) o;
+        return Objects.equals(getId(), actor.getId());
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(getId());
+    }
+}

--- a/src/main/java/com/agonyengine/model/command/HelpCommand.java
+++ b/src/main/java/com/agonyengine/model/command/HelpCommand.java
@@ -1,5 +1,6 @@
 package com.agonyengine.model.command;
 
+import com.agonyengine.model.actor.Actor;
 import com.agonyengine.model.stomp.GameOutput;
 import com.agonyengine.repository.VerbRepository;
 import org.springframework.data.domain.Sort;
@@ -16,7 +17,7 @@ public class HelpCommand {
         this.verbRepository = verbRepository;
     }
 
-    public void invoke(GameOutput output) {
+    public void invoke(Actor actor, GameOutput output) {
         verbRepository
             .findAll(Sort.by(Sort.Direction.ASC,"priority", "name"))
             .forEach(v -> output.append(v.getName().toUpperCase()));

--- a/src/main/java/com/agonyengine/model/command/LookCommand.java
+++ b/src/main/java/com/agonyengine/model/command/LookCommand.java
@@ -1,11 +1,12 @@
 package com.agonyengine.model.command;
 
+import com.agonyengine.model.actor.Actor;
 import com.agonyengine.model.stomp.GameOutput;
 import org.springframework.stereotype.Component;
 
 @Component
 public class LookCommand {
-    public void invoke(GameOutput output) {
+    public void invoke(Actor actor, GameOutput output) {
         output.append("[black]You see nothing but the inky void swirling around you.");
     }
 }

--- a/src/main/java/com/agonyengine/model/command/SayCommand.java
+++ b/src/main/java/com/agonyengine/model/command/SayCommand.java
@@ -1,12 +1,45 @@
 package com.agonyengine.model.command;
 
+import com.agonyengine.model.actor.Actor;
 import com.agonyengine.model.interpret.QuotedString;
 import com.agonyengine.model.stomp.GameOutput;
+import com.agonyengine.repository.ActorRepository;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.List;
 
 @Component
 public class SayCommand {
-    public void invoke(GameOutput output, QuotedString message) {
-        output.append("[cyan]You say '" + message.getText() + "[cyan]'");
+    private SimpMessagingTemplate simpMessagingTemplate;
+    private ActorRepository actorRepository;
+
+    @Inject
+    public SayCommand(SimpMessagingTemplate simpMessagingTemplate, ActorRepository actorRepository) {
+        this.simpMessagingTemplate = simpMessagingTemplate;
+        this.actorRepository = actorRepository;
+    }
+
+    public void invoke(Actor actor, GameOutput output, QuotedString message) {
+        List<Actor> actors = actorRepository.findByGameMapAndXAndY(actor.getGameMap(), actor.getX(), actor.getY());
+
+        actors.forEach(target -> {
+           if (target.equals(actor)) {
+               output.append("[cyan]You say '" + message.getText() + "[cyan]'");
+           } else {
+               // TODO need a database model for dynamically defined channels, for now assume everything is a say
+               GameOutput formatted = target.onChannel(actor, message.getText());
+
+               // TODO this stuff will need to be pulled out into a generic utility since it will be used every time we push messages into other browsers
+               SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
+
+               headerAccessor.setSessionId(target.getSessionId());
+               headerAccessor.setLeaveMutable(true);
+
+               simpMessagingTemplate.convertAndSendToUser(target.getSessionUsername(), "/queue/output", formatted, headerAccessor.getMessageHeaders());
+           }
+        });
     }
 }

--- a/src/main/java/com/agonyengine/model/command/ScoreCommand.java
+++ b/src/main/java/com/agonyengine/model/command/ScoreCommand.java
@@ -1,11 +1,12 @@
 package com.agonyengine.model.command;
 
+import com.agonyengine.model.actor.Actor;
 import com.agonyengine.model.stomp.GameOutput;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ScoreCommand {
-    public void invoke(GameOutput output) {
+    public void invoke(Actor actor, GameOutput output) {
         output.append("[dwhite]Not implemented yet.");
     }
 }

--- a/src/main/java/com/agonyengine/repository/ActorRepository.java
+++ b/src/main/java/com/agonyengine/repository/ActorRepository.java
@@ -1,0 +1,13 @@
+package com.agonyengine.repository;
+
+import com.agonyengine.model.actor.Actor;
+import com.agonyengine.model.actor.GameMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ActorRepository extends JpaRepository<Actor, UUID> {
+    Actor findBySessionUsername(String sessionUsername);
+    List<Actor> findByGameMapAndXAndY(GameMap gameMap, Integer x, Integer y);
+}

--- a/src/main/java/com/agonyengine/resource/MainResource.java
+++ b/src/main/java/com/agonyengine/resource/MainResource.java
@@ -151,7 +151,7 @@ public class MainResource {
 
     @RequestMapping("/play")
     public String play(HttpSession httpSession) {
-        if (httpSession.getAttribute("actor") == null) {
+        if (httpSession.getAttribute("actor_template") == null) {
             return "redirect:/account";
         }
 
@@ -169,7 +169,7 @@ public class MainResource {
                 throw new NoSuchActorException("PAT belongs to a different user");
             }
 
-            httpSession.setAttribute("actor", id);
+            httpSession.setAttribute("actor_template", id);
 
             return "redirect:/play";
         } catch (NoSuchActorException e) {

--- a/src/main/java/com/agonyengine/resource/StompDisconnectListener.java
+++ b/src/main/java/com/agonyengine/resource/StompDisconnectListener.java
@@ -1,0 +1,38 @@
+package com.agonyengine.resource;
+
+import com.agonyengine.model.actor.Actor;
+import com.agonyengine.repository.ActorRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import javax.inject.Inject;
+
+@Component
+public class StompDisconnectListener implements ApplicationListener<SessionDisconnectEvent> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StompDisconnectListener.class);
+
+    private ActorRepository actorRepository;
+
+    @Inject
+    public StompDisconnectListener(ActorRepository actorRepository) {
+        this.actorRepository = actorRepository;
+    }
+
+    @Override
+    public void onApplicationEvent(SessionDisconnectEvent event) {
+        SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(event.getMessage());
+        Actor actor = actorRepository.findBySessionUsername(headerAccessor.getUser().getName());
+
+        if (actor == null) {
+            return;
+        }
+
+        LOGGER.info("{} has disconnected from the game", actor.getName());
+
+        actorRepository.delete(actor);
+    }
+}

--- a/src/main/resources/db/migration/V0007__actor_schema.sql
+++ b/src/main/resources/db/migration/V0007__actor_schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE actor (
+  id UUID NOT NULL,
+  name VARCHAR(256) NOT NULL,
+  session_username VARCHAR(256),
+  session_id VARCHAR(256),
+  game_map_id UUID,
+  x INTEGER,
+  y INTEGER,
+  PRIMARY KEY (id),
+  CONSTRAINT ACTOR_GAME_MAP_FK FOREIGN KEY (game_map_id) REFERENCES game_map (id)
+);

--- a/src/test/java/com/agonyengine/resource/MainResourceTest.java
+++ b/src/test/java/com/agonyengine/resource/MainResourceTest.java
@@ -246,7 +246,7 @@ public class MainResourceTest {
 
     @Test
     public void testPlay() {
-        when(httpSession.getAttribute(eq("actor"))).thenReturn("actor_id");
+        when(httpSession.getAttribute(eq("actor_template"))).thenReturn("actor_id");
 
         assertEquals("play", resource.play(httpSession));
     }
@@ -263,7 +263,7 @@ public class MainResourceTest {
 
         assertEquals("redirect:/play", view);
 
-        verify(httpSession).setAttribute(eq("actor"), eq(actorId.toString()));
+        verify(httpSession).setAttribute(eq("actor_template"), eq(actorId.toString()));
     }
 
     @Test
@@ -278,7 +278,7 @@ public class MainResourceTest {
 
         assertEquals("redirect:/account", view);
 
-        verify(httpSession, never()).setAttribute(eq("actor"), anyString());
+        verify(httpSession, never()).setAttribute(eq("actor_template"), anyString());
     }
 
     @Test
@@ -293,7 +293,7 @@ public class MainResourceTest {
 
         assertEquals("redirect:/account", view);
 
-        verify(httpSession, never()).setAttribute(eq("actor"), anyString());
+        verify(httpSession, never()).setAttribute(eq("actor_template"), anyString());
     }
 
     @Test

--- a/src/test/java/com/agonyengine/resource/StompDisconnectListenerTest.java
+++ b/src/test/java/com/agonyengine/resource/StompDisconnectListenerTest.java
@@ -1,0 +1,79 @@
+package com.agonyengine.resource;
+
+import com.agonyengine.model.actor.Actor;
+import com.agonyengine.repository.ActorRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class StompDisconnectListenerTest {
+    @Mock
+    private ActorRepository actorRepository;
+
+    @Mock
+    private SessionDisconnectEvent disconnectEvent;
+
+    @Mock
+    private Principal principal;
+
+    @Mock
+    private Actor actor;
+
+    private Message<byte[]> message;
+
+    private StompDisconnectListener stompDisconnectListener;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        message = buildMockMessage();
+
+        stompDisconnectListener = new StompDisconnectListener(actorRepository);
+    }
+
+    @Test
+    public void testApplicationEvent() {
+        when(disconnectEvent.getMessage()).thenReturn(message);
+        when(principal.getName()).thenReturn("SessionUser");
+        when(actorRepository.findBySessionUsername(eq("SessionUser"))).thenReturn(actor);
+        when(actor.getName()).thenReturn("Stan");
+
+        stompDisconnectListener.onApplicationEvent(disconnectEvent);
+
+        verify(actorRepository).delete(eq(actor));
+    }
+
+    @Test
+    public void testActorNotFound() {
+        when(disconnectEvent.getMessage()).thenReturn(message);
+        when(principal.getName()).thenReturn("SessionUser");
+        when(actorRepository.findBySessionUsername(eq("SessionUser"))).thenReturn(null);
+
+        stompDisconnectListener.onApplicationEvent(disconnectEvent);
+
+        verify(actorRepository, never()).delete(eq(actor));
+    }
+
+    private Message<byte[]> buildMockMessage() {
+        Map<String, Object> headers = new HashMap<>();
+
+        headers.put(SimpMessageHeaderAccessor.USER_HEADER, principal);
+
+        return new GenericMessage<>(new byte[0], headers);
+    }
+}


### PR DESCRIPTION
The SAY command now actually passes your message to others who are logged on at the same time!

Actors are the in-game representation of items and creatures. Until this point we've been able to log in but we effectively haven't had any "physical" representation within the game world. Recently I added GameMap which provides a place, and here are Actors that provide things. Now when you enter the game an Actor is created for you, and when you disconnect your Actor is deleted. When you talk the game can figure out if there are other Actors in the same location as you and pass your messages to them.

This code is very simple, messy and fragile in some places. The next few iterations will need to improve on the code quality as we flesh out the game's new data model. The potential is very exciting, however, since this new framework opens the door for LOOK to show you other players in the game, for movement, inventory, equipment, stats, tiles and tilesets...