### PR TITLE
Log in different characters from the same account

### DIFF
--- a/src/main/java/com/agonyengine/repository/ActorRepository.java
+++ b/src/main/java/com/agonyengine/repository/ActorRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 import java.util.UUID;
 
 public interface ActorRepository extends JpaRepository<Actor, UUID> {
-    Actor findBySessionUsername(String sessionUsername);
+    Actor findBySessionUsernameAndSessionId(String sessionUsername, String sessionId);
     List<Actor> findByGameMapAndXAndY(GameMap gameMap, Integer x, Integer y);
 }

--- a/src/main/java/com/agonyengine/resource/StompDisconnectListener.java
+++ b/src/main/java/com/agonyengine/resource/StompDisconnectListener.java
@@ -25,7 +25,9 @@ public class StompDisconnectListener implements ApplicationListener<SessionDisco
     @Override
     public void onApplicationEvent(SessionDisconnectEvent event) {
         SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(event.getMessage());
-        Actor actor = actorRepository.findBySessionUsername(headerAccessor.getUser().getName());
+        Actor actor = actorRepository.findBySessionUsernameAndSessionId(
+            headerAccessor.getUser().getName(),
+            event.getSessionId());
 
         if (actor == null) {
             return;

--- a/src/main/java/com/agonyengine/resource/WebSocketResource.java
+++ b/src/main/java/com/agonyengine/resource/WebSocketResource.java
@@ -106,7 +106,7 @@ public class WebSocketResource {
         output.append("");
         output.append("[dwhite]> ");
 
-        Actor actor = actorRepository.findBySessionUsername(principal.getName());
+        Actor actor = actorRepository.findBySessionUsernameAndSessionId(principal.getName(), getStompSessionId(message));
 
         if (actor == null) {
             PlayerActorTemplate pat = playerActorTemplateRepository
@@ -136,8 +136,8 @@ public class WebSocketResource {
 
     @MessageMapping("/input")
     @SendToUser(value = "/queue/output", broadcast = false)
-    public GameOutput onInput(Principal principal, UserInput input) {
-        Actor actor = actorRepository.findBySessionUsername(principal.getName());
+    public GameOutput onInput(Principal principal, UserInput input, Message<byte[]> message) {
+        Actor actor = actorRepository.findBySessionUsernameAndSessionId(principal.getName(), getStompSessionId(message));
         GameOutput output = new GameOutput();
         List<List<String>> sentences = inputTokenizer.tokenize(input.getInput());
 

--- a/src/test/java/com/agonyengine/resource/StompDisconnectListenerTest.java
+++ b/src/test/java/com/agonyengine/resource/StompDisconnectListenerTest.java
@@ -49,8 +49,9 @@ public class StompDisconnectListenerTest {
     @Test
     public void testApplicationEvent() {
         when(disconnectEvent.getMessage()).thenReturn(message);
+        when(disconnectEvent.getSessionId()).thenReturn("SessionId");
         when(principal.getName()).thenReturn("SessionUser");
-        when(actorRepository.findBySessionUsername(eq("SessionUser"))).thenReturn(actor);
+        when(actorRepository.findBySessionUsernameAndSessionId(eq("SessionUser"), eq("SessionId"))).thenReturn(actor);
         when(actor.getName()).thenReturn("Stan");
 
         stompDisconnectListener.onApplicationEvent(disconnectEvent);
@@ -61,8 +62,9 @@ public class StompDisconnectListenerTest {
     @Test
     public void testActorNotFound() {
         when(disconnectEvent.getMessage()).thenReturn(message);
+        when(disconnectEvent.getSessionId()).thenReturn("SessionId");
         when(principal.getName()).thenReturn("SessionUser");
-        when(actorRepository.findBySessionUsername(eq("SessionUser"))).thenReturn(null);
+        when(actorRepository.findBySessionUsernameAndSessionId(eq("SessionUser"), eq("SessionId"))).thenReturn(null);
 
         stompDisconnectListener.onApplicationEvent(disconnectEvent);
 

--- a/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
+++ b/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
@@ -111,7 +111,7 @@ public class WebSocketResourceTest {
         when(pat.getAccount()).thenReturn("Dude007");
         when(pat.getGivenName()).thenReturn("Frank");
         when(actor.getName()).thenReturn("Frank");
-        when(actorRepository.findBySessionUsername(eq("Shepherd"))).thenReturn(actor);
+        when(actorRepository.findBySessionUsernameAndSessionId(eq("Shepherd"), eq(sessionId.toString()))).thenReturn(actor);
         when(sessionRepository.findById(eq(sessionId.toString()))).thenReturn(session);
 
         when(actorRepository.save(any(Actor.class))).thenAnswer(i -> {
@@ -150,7 +150,7 @@ public class WebSocketResourceTest {
 
     @Test
     public void testOnSubscribeNullActor() {
-        when(actorRepository.findBySessionUsername(eq("Shepherd"))).thenReturn(null);
+        when(actorRepository.findBySessionUsernameAndSessionId(eq("Shepherd"), eq(sessionId.toString()))).thenReturn(null);
         when(playerActorTemplateRepository.findById(any(UUID.class))).thenReturn(Optional.of(pat));
         when(gameMapRepository.getOne(eq(defaultMapId))).thenReturn(gameMap);
         when(session.getAttribute(eq("actor_template"))).thenReturn(UUID.randomUUID().toString());
@@ -196,7 +196,7 @@ public class WebSocketResourceTest {
         when(verbRepository.findAll(any(Sort.class))).thenReturn(verbs);
         when(applicationContext.getBean(eq("alphaCommand"))).thenReturn(alphaBean);
 
-        GameOutput output = resource.onInput(principal, input);
+        GameOutput output = resource.onInput(principal, input, message);
 
         assertTrue(output.getOutput().stream().anyMatch("Test Passed"::equals));
 
@@ -223,7 +223,7 @@ public class WebSocketResourceTest {
         when(verbs.get(0).isQuoting()).thenReturn(true);
         when(applicationContext.getBean(eq("alphaCommand"))).thenReturn(alphaBean);
 
-        GameOutput output = resource.onInput(principal, input);
+        GameOutput output = resource.onInput(principal, input, message);
 
         assertTrue(output.getOutput().stream().anyMatch("Test Passed: baker charlie dog easy fox."::equals));
 
@@ -247,7 +247,7 @@ public class WebSocketResourceTest {
         when(verbs.get(0).isQuoting()).thenReturn(true);
         when(applicationContext.getBean(eq("alphaCommand"))).thenReturn(alphaBean);
 
-        GameOutput output = resource.onInput(principal, input);
+        GameOutput output = resource.onInput(principal, input, message);
 
         assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("cannot be empty")));
 
@@ -274,7 +274,7 @@ public class WebSocketResourceTest {
         when(verbs.get(0).isQuoting()).thenReturn(true);
         when(applicationContext.getBean(eq("alphaCommand"))).thenReturn(alphaBean);
 
-        GameOutput output = resource.onInput(principal, input);
+        GameOutput output = resource.onInput(principal, input, message);
 
         assertTrue(output.getOutput().stream().anyMatch("Test Passed: baker charlie dog easy fox."::equals));
 
@@ -303,7 +303,7 @@ public class WebSocketResourceTest {
         when(verbs.get(0).isQuoting()).thenReturn(true);
         when(applicationContext.getBean(eq("alphaCommand"))).thenReturn(alphaBean);
 
-        GameOutput output = resource.onInput(principal, input);
+        GameOutput output = resource.onInput(principal, input, message);
 
         assertTrue(output.getOutput().stream().anyMatch("Test Passed: baker. Charlie dog. Easy fox."::equals));
 
@@ -323,7 +323,7 @@ public class WebSocketResourceTest {
         when(applicationContext.getBean(eq("alphaCommand")))
             .thenThrow(new NoSuchBeanDefinitionException("alphaCommand"));
 
-        GameOutput output = resource.onInput(principal, input);
+        GameOutput output = resource.onInput(principal, input, message);
 
         assertTrue(output.getOutput().stream().anyMatch("[dwhite]No bean named 'alphaCommand' available"::equals));
 
@@ -339,7 +339,7 @@ public class WebSocketResourceTest {
         when(session.getAttribute(eq("actor"))).thenReturn(actorId.toString());
         when(playerActorTemplateRepository.findById(eq(actorId))).thenReturn(Optional.empty());
 
-        GameOutput output = resource.onInput(principal, input);
+        GameOutput output = resource.onInput(principal, input, message);
 
         assertTrue(output.getOutput().size() >= 3);
     }


### PR DESCRIPTION
If you tried to log in two different characters from the same account it would mistakenly log the same character twice and only make one Actor. You would still get what looked like two sessions in two browsers, but they couldn't talk to one another. This makes it so we distinguish based on both the STOMP session ID and the STOMP username which will be unique even across different windows in the same browser.