### PR TITLE
Fix website badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agony-engine
 ![AWS CodeBuild](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoibHRwM2YxOVlSQmJWTzU4NE1BZC9UU1czK1hTaG5iTzRwUG1TS2QyT1RBTVNjTHhqUFNNenhwSkZHZFhraVJ4VkhkTWVhQVZHYWx6VEg1aXMzZEpUWkYwPSIsIml2UGFyYW1ldGVyU3BlYyI6Ii9RcC9Ob1ZMU0dvbi8yRnciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
-[![Website](https://img.shields.io/website-up-down-brightgreen-red/http/shields.io.svg?label=website)](https://agonyengine.com)
+[![Website](https://img.shields.io/website-up-down-brightgreen-red/https/agonyengine.com.svg?label=website)](https://agonyengine.com)
 
 **A modern, customizable engine for web based MUDs.**
 


### PR DESCRIPTION
Noticed it was showing whether shields.io was up or down, not the MUD's website. Oops!