### PR TITLE
Basic implementation of movement

### DIFF
--- a/src/main/java/com/agonyengine/config/MovementConfiguration.java
+++ b/src/main/java/com/agonyengine/config/MovementConfiguration.java
@@ -1,0 +1,59 @@
+package com.agonyengine.config;
+
+import com.agonyengine.model.command.Direction;
+import com.agonyengine.model.command.MoveCommand;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.inject.Inject;
+
+@Configuration
+public class MovementConfiguration {
+    private ApplicationContext applicationContext;
+
+    @Inject
+    public MovementConfiguration(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Bean(name = "northDirection")
+    public Direction northDirection() {
+        return new Direction("north", "south", 0, 1);
+    }
+
+    @Bean(name = "eastDirection")
+    public Direction eastDirection() {
+        return new Direction("east", "west", 1, 0);
+    }
+
+    @Bean(name = "southDirection")
+    public Direction southDirection() {
+        return new Direction("south", "north", 0, -1);
+    }
+
+    @Bean(name = "westDirection")
+    public Direction westDirection() {
+        return new Direction("west", "east", -1, 0);
+    }
+
+    @Bean(name = "northCommand")
+    public MoveCommand northCommand() {
+        return new MoveCommand(northDirection(), applicationContext);
+    }
+
+    @Bean(name = "eastCommand")
+    public MoveCommand eastCommand() {
+        return new MoveCommand(eastDirection(), applicationContext);
+    }
+
+    @Bean(name = "southCommand")
+    public MoveCommand southCommand() {
+        return new MoveCommand(southDirection(), applicationContext);
+    }
+
+    @Bean(name = "westCommand")
+    public MoveCommand westCommand() {
+        return new MoveCommand(westDirection(), applicationContext);
+    }
+}

--- a/src/main/java/com/agonyengine/model/actor/GameMap.java
+++ b/src/main/java/com/agonyengine/model/actor/GameMap.java
@@ -72,11 +72,21 @@ public class GameMap {
         return tiles[computeIndex(x, y)];
     }
 
+    public boolean hasTile(int x, int y) {
+        int index = computeIndex(x, y);
+
+        return index >= 0 && index < tiles.length;
+    }
+
     public void setTile(int x, int y, byte value) {
         tiles[computeIndex(x, y)] = value;
     }
 
     private int computeIndex(int x, int y) {
+        if (x < 0 || x >= width) {
+            return -1;
+        }
+
         return y * width + x;
     }
 }

--- a/src/main/java/com/agonyengine/model/command/Direction.java
+++ b/src/main/java/com/agonyengine/model/command/Direction.java
@@ -1,0 +1,31 @@
+package com.agonyengine.model.command;
+
+public class Direction {
+    private String name;
+    private String opposite;
+    private int x;
+    private int y;
+
+    public Direction(String name, String opposite, int x, int y) {
+        this.name = name;
+        this.opposite = opposite;
+        this.x = x;
+        this.y = y;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getOpposite() {
+        return opposite;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+}

--- a/src/main/java/com/agonyengine/model/command/MoveCommand.java
+++ b/src/main/java/com/agonyengine/model/command/MoveCommand.java
@@ -1,0 +1,46 @@
+package com.agonyengine.model.command;
+
+import com.agonyengine.model.actor.Actor;
+import com.agonyengine.model.stomp.GameOutput;
+import com.agonyengine.repository.ActorRepository;
+import com.agonyengine.service.InvokerService;
+import org.springframework.context.ApplicationContext;
+
+import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
+
+public class MoveCommand {
+    private Direction direction;
+    private ActorRepository actorRepository;
+    private InvokerService invokerService;
+    private ApplicationContext applicationContext;
+
+    public MoveCommand(Direction direction, ApplicationContext applicationContext) {
+        this.direction = direction;
+        this.applicationContext = applicationContext;
+    }
+
+    @PostConstruct
+    private void postConstruct() {
+        this.actorRepository = applicationContext.getBean("actorRepository", ActorRepository.class);
+        this.invokerService = applicationContext.getBean("invokerService", InvokerService.class);
+    }
+
+    @Transactional
+    public void invoke(Actor actor, GameOutput output) {
+        int newX = actor.getX() + direction.getX();
+        int newY = actor.getY() + direction.getY();
+
+        if (!actor.getGameMap().hasTile(newX, newY)) {
+            output.append("Alas, you cannot go that way.");
+            return;
+        }
+
+        actor.setX(newX);
+        actor.setY(newY);
+
+        actorRepository.save(actor);
+
+        invokerService.invoke("lookCommand", actor, output);
+    }
+}

--- a/src/main/java/com/agonyengine/resource/WebSocketResource.java
+++ b/src/main/java/com/agonyengine/resource/WebSocketResource.java
@@ -26,6 +26,7 @@ import org.springframework.session.SessionRepository;
 import org.springframework.stereotype.Controller;
 
 import javax.inject.Inject;
+import javax.transaction.Transactional;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -83,6 +84,7 @@ public class WebSocketResource {
         greeting = greetingReader.lines().collect(Collectors.toList());
     }
 
+    @Transactional
     @SubscribeMapping("/queue/output")
     public GameOutput onSubscribe(Principal principal, Message<byte[]> message) {
         Session session = getSpringSession(message);
@@ -136,6 +138,7 @@ public class WebSocketResource {
         return output;
     }
 
+    @Transactional
     @MessageMapping("/input")
     @SendToUser(value = "/queue/output", broadcast = false)
     public GameOutput onInput(Principal principal, UserInput input, Message<byte[]> message) {

--- a/src/main/java/com/agonyengine/service/InvokerService.java
+++ b/src/main/java/com/agonyengine/service/InvokerService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.ReflectionUtils;
 
 import javax.inject.Inject;
+import javax.transaction.Transactional;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -20,6 +21,7 @@ public class InvokerService {
         this.applicationContext = applicationContext;
     }
 
+    @Transactional
     public void invoke(String verbBeanName, Actor actor, GameOutput output, Object ... arguments) {
         Object verbBean = applicationContext.getBean(verbBeanName);
         Method verbMethod = ReflectionUtils.findMethod(verbBean.getClass(), "invoke",

--- a/src/main/resources/db/migration/R__maps.sql
+++ b/src/main/resources/db/migration/R__maps.sql
@@ -1,3 +1,3 @@
 INSERT INTO game_map (id, width, tiles)
-VALUES ('5231e20f-0658-4685-9396-6e69ebfb2c3b', 3, decode('000000000000000000', 'hex')) ON CONFLICT (id) DO
+VALUES ('5231e20f-0658-4685-9396-6e69ebfb2c3b', 3, decode('000102030405060708', 'hex')) ON CONFLICT (id) DO
 UPDATE SET width=EXCLUDED.width, tiles=EXCLUDED.tiles;

--- a/src/main/resources/db/migration/R__verbs.sql
+++ b/src/main/resources/db/migration/R__verbs.sql
@@ -1,3 +1,19 @@
+INSERT INTO verb (name, priority, bean)
+VALUES ('north', 0, 'northCommand') ON CONFLICT (name) DO
+UPDATE SET name=EXCLUDED.name, priority=EXCLUDED.priority, bean=EXCLUDED.bean;
+
+INSERT INTO verb (name, priority, bean)
+VALUES ('east', 0, 'eastCommand') ON CONFLICT (name) DO
+UPDATE SET name=EXCLUDED.name, priority=EXCLUDED.priority, bean=EXCLUDED.bean;
+
+INSERT INTO verb (name, priority, bean)
+VALUES ('south', 0, 'southCommand') ON CONFLICT (name) DO
+UPDATE SET name=EXCLUDED.name, priority=EXCLUDED.priority, bean=EXCLUDED.bean;
+
+INSERT INTO verb (name, priority, bean)
+VALUES ('west', 0, 'westCommand') ON CONFLICT (name) DO
+UPDATE SET name=EXCLUDED.name, priority=EXCLUDED.priority, bean=EXCLUDED.bean;
+
 INSERT INTO verb (name, priority, quoting, bean)
 VALUES ('say', 500, TRUE, 'sayCommand') ON CONFLICT (name) DO
 UPDATE SET name=EXCLUDED.name, priority=EXCLUDED.priority, quoting=EXCLUDED.quoting, bean=EXCLUDED.bean;

--- a/src/test/java/com/agonyengine/model/actor/GameMapTest.java
+++ b/src/test/java/com/agonyengine/model/actor/GameMapTest.java
@@ -7,12 +7,14 @@ import org.mockito.MockitoAnnotations;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GameMapTest {
     private byte[] defaultMap = new byte[] {
-        0x07, 0x08, 0x09,
+        0x01, 0x02, 0x03,
         0x04, 0x05, 0x06,
-        0x01, 0x02, 0x03
+        0x07, 0x08, 0x09,
     };
 
     private GameMap map;
@@ -45,9 +47,9 @@ public class GameMapTest {
     @Test
     public void testTiles() {
         byte[] updatedMap = new byte[] {
-            0x10, 0x11, 0x12,
+            0x0A, 0x0B, 0x0C,
             0x0D, 0x0E, 0x0F,
-            0x0A, 0x0B, 0x0C
+            0x10, 0x11, 0x12,
         };
 
         assertEquals(defaultMap, map.getTiles());
@@ -64,5 +66,37 @@ public class GameMapTest {
         map.setTile(1, 1, (byte)0x7F);
 
         assertEquals((byte)0x7F, map.getTile(1, 1));
+    }
+
+    @Test
+    public void testGetTiles() {
+        assertEquals(0x1, map.getTile(0, 0));
+        assertEquals(0x2, map.getTile(1, 0));
+        assertEquals(0x3, map.getTile(2, 0));
+        assertEquals(0x4, map.getTile(0, 1));
+        assertEquals(0x5, map.getTile(1, 1));
+        assertEquals(0x6, map.getTile(2, 1));
+        assertEquals(0x7, map.getTile(0, 2));
+        assertEquals(0x8, map.getTile(1, 2));
+        assertEquals(0x9, map.getTile(2, 2));
+    }
+
+    @Test
+    public void testCorners() {
+        assertFalse(map.hasTile(-1, 0));
+        assertFalse(map.hasTile(0, -1));
+        assertTrue(map.hasTile(0, 0));
+
+        assertFalse(map.hasTile(3, 0));
+        assertFalse(map.hasTile(2, -1));
+        assertTrue(map.hasTile(2, 0));
+
+        assertFalse(map.hasTile(0, 3));
+        assertFalse(map.hasTile(-1, 2));
+        assertTrue(map.hasTile(0, 2));
+
+        assertFalse(map.hasTile(2, 3));
+        assertFalse(map.hasTile(3, 2));
+        assertTrue(map.hasTile(2, 2));
     }
 }


### PR DESCRIPTION
* Direction class captures normalized change to your (x,y) when that direction is applied to it.
* One MoveCommand for all movement, avoiding code duplication. There is some Spring weirdness with this class because of the order that things get instantiated in when Spring first starts up. MoveCommand itself is not annotated as a Component. Instead the instances of it are created in MovementConfiguration which happens early on in the Spring initialization. The MoveCommand needs some of the other services like ActorRepository and InvokerService but those don't exist yet when it is created, so the normal constructor injection is impossible. Instead I used a little bit of a hack and pass in the ApplicationContext. In a PostConstruct method I use the ApplicationContext (which should be done loading by then) to get the services I need. A little more complicated than I'd like it to be, but it seems to work.
* Discovered some bugs with the way the tile math worked. Used some TDD to resolve them:
  * Used a test map with a unique value for each tile.
  * Wrote a test to assert that each tile I expected had the value I expected (turns out they were backwards).
  * Wrote tests to assert that tiles adjacent to each corner did not exist (they did).
  * Finally fixed the GameMap to meet the assertions in the new tests (it does now).
* Had to fiddle around with JPA transactions. Now everything from the WebSocketResource down to the commands is within the same transaction due to Transactional annotations, which allows for Hibernate's lazy loading to work as you'd expect it to.
* The default map now uses unique values for each tile rather than all zeroes, to aid in debugging.