### PR TITLE
More aggressive reconnect

### DIFF
--- a/src/main/java/com/agonyengine/resource/WebSocketResource.java
+++ b/src/main/java/com/agonyengine/resource/WebSocketResource.java
@@ -138,6 +138,13 @@ public class WebSocketResource {
 
             commService.echoToRoom(actor, new GameOutput(String.format("[yellow]%s appears in a puff of smoke!", actor.getName())), actor);
         } else {
+            GameOutput reconnect = new GameOutput();
+
+            reconnect.append("[yellow]Your connection has been reconnected in another browser!");
+            reconnect.append("<script type=\"text/javascript\">setTimeout(function() { window.location=\"/account\"; }, 1000);</script>");
+
+            commService.echo(actor, reconnect);
+
             actor.setDisconnectedDate(null);
             actor.setSessionUsername(principal.getName());
             actor.setSessionId(getStompSessionId(message));

--- a/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
+++ b/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
@@ -168,6 +168,7 @@ public class WebSocketResourceTest {
         GameOutput output = resource.onSubscribe(principal, message);
 
         verify(commService).echoToRoom(eq(actor), any(GameOutput.class), eq(actor));
+        verify(commService).echo(eq(actor), any(GameOutput.class));
         verify(invokerService).invoke(eq(actor), any(GameOutput.class), isNull(), anyList());
         verify(actor).setDisconnectedDate(isNull());
         verify(actor).setSessionUsername(eq("Shepherd"));


### PR DESCRIPTION
Briefly show a message to the session that is being booted before kicking them back to the account page.

Fixes #59 .