### PR TITLE
Fix the inventory problems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.agonyengine'
-version '0.7.0-SNAPSHOT'
+version '0.7.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/agonyengine/model/command/QuitCommand.java
+++ b/src/main/java/com/agonyengine/model/command/QuitCommand.java
@@ -5,7 +5,6 @@ import com.agonyengine.model.interpret.QuotedString;
 import com.agonyengine.model.stomp.GameOutput;
 import com.agonyengine.repository.ActorRepository;
 import com.agonyengine.service.CommService;
-import com.agonyengine.service.InvokerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -13,20 +12,20 @@ import org.springframework.util.StringUtils;
 
 import javax.inject.Inject;
 import javax.transaction.Transactional;
-import java.util.Arrays;
 
 @Component
 public class QuitCommand {
     private static final Logger LOGGER = LoggerFactory.getLogger(QuitCommand.class);
 
     private ActorRepository actorRepository;
-    private InvokerService invokerService;
     private CommService commService;
 
     @Inject
-    public QuitCommand(ActorRepository actorRepository, InvokerService invokerService, CommService commService) {
+    public QuitCommand(
+        ActorRepository actorRepository,
+        CommService commService) {
+
         this.actorRepository = actorRepository;
-        this.invokerService = invokerService;
         this.commService = commService;
     }
 
@@ -37,11 +36,6 @@ public class QuitCommand {
             return;
         }
 
-        // TODO: keep your inventory and reattach it when you come back
-        // for now, just drop it all on the floor to avoid SQL constraint violations
-        actorRepository.findByGameMap(actor.getInventory())
-            .forEach(item -> invokerService.invoke(actor, output, null, Arrays.asList("drop", item.getName())));
-
         output.append(String.format("[yellow]Goodbye, %s!", actor.getName()));
         output.append("<script type=\"text/javascript\">setTimeout(function() { window.location=\"/account\"; }, 1000);</script>");
 
@@ -49,6 +43,7 @@ public class QuitCommand {
 
         commService.echoToRoom(actor, new GameOutput(String.format("[yellow]%s disappears in a puff of smoke!", StringUtils.capitalize(actor.getName()))), actor);
 
-        actorRepository.delete(actor);
+        actor.setGameMap(null);
+        actorRepository.save(actor);
     }
 }

--- a/src/main/java/com/agonyengine/model/command/WhoCommand.java
+++ b/src/main/java/com/agonyengine/model/command/WhoCommand.java
@@ -21,11 +21,13 @@ public class WhoCommand {
 
     @Transactional
     public void invoke(Actor actor, GameOutput output) {
-        List<Actor> actors = actorRepository.findBySessionUsernameIsNotNullAndSessionIdIsNotNull(Sort.by(Sort.Direction.ASC, "name"));
+        List<Actor> actors = actorRepository.findBySessionUsernameIsNotNullAndSessionIdIsNotNullAndGameMapIsNotNull(Sort.by(Sort.Direction.ASC, "name"));
 
         output.append("[dwhite][ [white]Who is Online [dwhite]]");
 
-        actors.forEach(a -> output.append(String.format("[dwhite]%s", a.getName())));
+        actors.forEach(a -> output.append(String.format("[dwhite]%s%s",
+                a.getName(),
+                a.getDisconnectedDate() != null ? " [yellow][[dred]LINK DEAD[yellow]]" : "")));
 
         output.append("");
         output.append(String.format("%d player%s online.", actors.size(), actors.size() == 1 ? "" : "s"));

--- a/src/main/java/com/agonyengine/repository/ActorRepository.java
+++ b/src/main/java/com/agonyengine/repository/ActorRepository.java
@@ -16,6 +16,6 @@ public interface ActorRepository extends JpaRepository<Actor, UUID> {
     List<Actor> findByGameMap(GameMap gameMap);
     List<Actor> findByGameMapAndXAndY(GameMap gameMap, Integer x, Integer y);
     Optional<Actor> findByActorTemplate(PlayerActorTemplate playerActorTemplate);
-    List<Actor> findBySessionUsernameIsNotNullAndSessionIdIsNotNull(Sort sort);
-    List<Actor> findByDisconnectedDateIsBefore(Date cutoff);
+    List<Actor> findBySessionUsernameIsNotNullAndSessionIdIsNotNullAndGameMapIsNotNull(Sort sort);
+    List<Actor> findByDisconnectedDateIsBeforeAndGameMapIsNotNull(Date cutoff);
 }

--- a/src/main/java/com/agonyengine/service/ReaperService.java
+++ b/src/main/java/com/agonyengine/service/ReaperService.java
@@ -20,7 +20,10 @@ public class ReaperService {
     private CommService commService;
 
     @Inject
-    public ReaperService(ActorRepository actorRepository, CommService commService) {
+    public ReaperService(
+        ActorRepository actorRepository,
+        CommService commService) {
+
         this.actorRepository = actorRepository;
         this.commService = commService;
     }
@@ -29,16 +32,15 @@ public class ReaperService {
     public void reapLinkDeadActors() {
         LOGGER.debug("Querying for link-dead players to reap...");
 
-        List<Actor> actors = actorRepository.findByDisconnectedDateIsBefore(new Date(System.currentTimeMillis() - (1000 * 60 * 30)));
+        List<Actor> actors = actorRepository.findByDisconnectedDateIsBeforeAndGameMapIsNotNull(new Date(System.currentTimeMillis() - (1000 * 60 * 30)));
 
         actors.forEach(actor -> {
             LOGGER.info("Reaping link-dead player: {}", actor.getName());
 
             commService.echoToRoom(actor, new GameOutput(String.format("[yellow]%s disappears in a puff of smoke!", actor.getName())), actor);
-
-            // TODO need to copy state from the actor to the template before deleting
+            actor.setGameMap(null);
         });
 
-        actorRepository.deleteAll(actors);
+        actorRepository.saveAll(actors);
     }
 }

--- a/src/test/java/com/agonyengine/model/command/QuitCommandTest.java
+++ b/src/test/java/com/agonyengine/model/command/QuitCommandTest.java
@@ -6,7 +6,6 @@ import com.agonyengine.model.interpret.QuotedString;
 import com.agonyengine.model.stomp.GameOutput;
 import com.agonyengine.repository.ActorRepository;
 import com.agonyengine.service.CommService;
-import com.agonyengine.service.InvokerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -22,9 +21,6 @@ import static org.mockito.Mockito.when;
 public class QuitCommandTest {
     @Mock
     private ActorRepository actorRepository;
-
-    @Mock
-    private InvokerService invokerService;
 
     @Mock
     private CommService commService;
@@ -56,7 +52,7 @@ public class QuitCommandTest {
         when(item.getName()).thenReturn("a flux capacitor");
         when(actorRepository.findByGameMap(inventory)).thenReturn(Collections.singletonList(item));
 
-        quitCommand = new QuitCommand(actorRepository, invokerService, commService);
+        quitCommand = new QuitCommand(actorRepository, commService);
     }
 
     @Test
@@ -65,8 +61,9 @@ public class QuitCommandTest {
 
         quitCommand.invoke(actor, output, quotedString);
 
+        verify(actor, never()).setGameMap(isNull());
         verify(commService, never()).echoToRoom(eq(actor), any(GameOutput.class), eq(actor));
-        verify(actorRepository, never()).delete(eq(actor));
+        verify(actorRepository, never()).save(eq(actor));
         verify(output, never()).append(contains("window.location"));
     }
 
@@ -76,8 +73,8 @@ public class QuitCommandTest {
 
         verify(output).append(contains("Goodbye, Scion!"));
         verify(output).append(contains("window.location"));
-        verify(invokerService).invoke(eq(actor), eq(output), isNull(), anyList());
         verify(commService).echoToRoom(eq(actor), any(GameOutput.class), eq(actor));
-        verify(actorRepository).delete(eq(actor));
+        verify(actor).setGameMap(isNull());
+        verify(actorRepository).save(eq(actor));
     }
 }

--- a/src/test/java/com/agonyengine/model/command/WhoCommandTest.java
+++ b/src/test/java/com/agonyengine/model/command/WhoCommandTest.java
@@ -10,6 +10,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Sort;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -47,7 +48,7 @@ public class WhoCommandTest {
 
         onlineActors.add(actor);
 
-        when(actorRepository.findBySessionUsernameIsNotNullAndSessionIdIsNotNull(any(Sort.class))).thenReturn(onlineActors);
+        when(actorRepository.findBySessionUsernameIsNotNullAndSessionIdIsNotNullAndGameMapIsNotNull(any(Sort.class))).thenReturn(onlineActors);
 
         whoCommand = new WhoCommand(actorRepository);
     }
@@ -56,7 +57,7 @@ public class WhoCommandTest {
     public void testInvoke() {
         whoCommand.invoke(actor, output);
 
-        verify(actorRepository).findBySessionUsernameIsNotNullAndSessionIdIsNotNull(any(Sort.class));
+        verify(actorRepository).findBySessionUsernameIsNotNullAndSessionIdIsNotNullAndGameMapIsNotNull(any(Sort.class));
 
         verify(output).append(contains("Who is Online"));
 
@@ -74,10 +75,28 @@ public class WhoCommandTest {
 
         whoCommand.invoke(actor, output);
 
-        verify(actorRepository).findBySessionUsernameIsNotNullAndSessionIdIsNotNull(any(Sort.class));
+        verify(actorRepository).findBySessionUsernameIsNotNullAndSessionIdIsNotNullAndGameMapIsNotNull(any(Sort.class));
 
         verify(output).append(contains("Who is Online"));
         verify(output).append(contains("Kadne"));
         verify(output).append(contains("1 player online."));
+    }
+
+    @Test
+    public void testInvokeLinkDead() {
+        when(onlineActors.get(0).getDisconnectedDate()).thenReturn(new Date());
+
+        whoCommand.invoke(actor, output);
+
+        verify(actorRepository).findBySessionUsernameIsNotNullAndSessionIdIsNotNullAndGameMapIsNotNull(any(Sort.class));
+
+        verify(output).append(contains("Who is Online"));
+
+        for (int i = 0; i < MOCK_ACTORS; i++) {
+            verify(output).append(contains("Actor-" + i));
+        }
+
+        verify(output, times(1)).append(contains("LINK DEAD"));
+        verify(output).append(contains("6 players online."));
     }
 }


### PR DESCRIPTION
When you leave the game we now just set your GameMap to null, effectively sending you to "the void". When you reconnect we bring you back to (0, 0) on the default map. That lets us keep your inventory and your Actor in the database without deleting anything, so your inventory is preserved and there's no complicated process to "reconnect" it. We shouldn't have any more problems with broken foreign key constraints preventing cleanup and people now get to keep their stuff. Win win!

* Closes #91
* Fixes #92