### PR TITLE
This was suggested in the documentation for webstomp-client

### DIFF
--- a/src/main/resources/static/js/client.js
+++ b/src/main/resources/static/js/client.js
@@ -45,7 +45,7 @@ $(document).keyup(function (event) {
 
 function connect() {
     socket = new SockJS('/mud');
-    stompClient = webstomp.over(socket);
+    stompClient = webstomp.over(socket, { "heartbeat" : false });
     stompClient.connect(
         {},
         function (frame) {

--- a/src/main/resources/templates/play.ftl
+++ b/src/main/resources/templates/play.ftl
@@ -24,8 +24,8 @@
 </div>
 
 <#include "scripts.inc.ftl">
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/webstomp-client@1.2.0/dist/webstomp.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sockjs-client@1.1.5/dist/sockjs.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/webstomp-client@1.2.3/dist/webstomp.min.js"></script>
 <script type="text/javascript" src="<@spring.url '/js/client.js'/>"></script>
 </body>
 </html>


### PR DESCRIPTION
https://github.com/JSteunou/webstomp-client suggests that you disable the heartbeat when you are also using sockjs-client. I tested a little locally and it seemed to work, but the proof will really be if we can run this way for a few days on the production instance and the reconnect problems go away.

I also updated the versions of sockjs-client and webstomp-client to the latest in case there were bug fixes.