### PR TITLE
Resolve the multi-tab reconnect issue

### DIFF
--- a/src/main/java/com/agonyengine/resource/WebSocketResource.java
+++ b/src/main/java/com/agonyengine/resource/WebSocketResource.java
@@ -14,6 +14,7 @@ import com.agonyengine.service.InvokerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.annotation.SendToUser;
@@ -84,10 +85,10 @@ public class WebSocketResource {
 
     @Transactional
     @SubscribeMapping("/queue/output")
-    public GameOutput onSubscribe(Principal principal, Message<byte[]> message) {
+    public GameOutput onSubscribe(Principal principal, Message<byte[]> message, @Header("actor") String actorId) {
         Session session = getSpringSession(message);
         GameOutput output = new GameOutput();
-        UUID actorTemplateId = UUID.fromString(session.getAttribute("actor_template"));
+        UUID actorTemplateId = UUID.fromString(actorId);
         PlayerActorTemplate pat = playerActorTemplateRepository
             .findById(actorTemplateId)
             .orElseThrow(() -> new NoSuchActorException("Player Actor Template not found: " + actorTemplateId.toString()));

--- a/src/main/resources/static/js/client.js
+++ b/src/main/resources/static/js/client.js
@@ -57,7 +57,8 @@ function connect() {
             stompClient.subscribe('/user/queue/output', function (message) {
                 var msg = JSON.parse(message.body);
                 showOutput(msg.output);
-            });
+            },
+            { "actor" : actor });
         },
         function () {
             if (isReconnecting === false) {

--- a/src/main/resources/templates/play.ftl
+++ b/src/main/resources/templates/play.ftl
@@ -26,6 +26,9 @@
 <#include "scripts.inc.ftl">
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sockjs-client@1.1.5/dist/sockjs.min.js"></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/webstomp-client@1.2.3/dist/webstomp.min.js"></script>
+<script type="text/javascript">
+    var actor = "${actor}";
+</script>
 <script type="text/javascript" src="<@spring.url '/js/client.js'/>"></script>
 </body>
 </html>

--- a/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
+++ b/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
@@ -128,7 +128,6 @@ public class WebSocketResourceTest {
         when(actor.getGameMap()).thenReturn(gameMap);
         when(actorRepository.findBySessionUsernameAndSessionId(eq("Shepherd"), eq(sessionId.toString()))).thenReturn(actor);
         when(sessionRepository.findById(eq(sessionId.toString()))).thenReturn(session);
-        when(session.getAttribute(eq("actor_template"))).thenReturn(actorTemplateId.toString());
         when(session.getAttribute(eq("remoteIpAddress"))).thenReturn(remoteIpAddress);
         when(playerActorTemplateRepository.findById(eq(actorTemplateId))).thenReturn(Optional.of(pat));
         when(actorRepository.findByActorTemplate(eq(pat))).thenReturn(Optional.of(actor));
@@ -167,7 +166,7 @@ public class WebSocketResourceTest {
 
     @Test
     public void testOnSubscribeReconnectInWorld() {
-        GameOutput output = resource.onSubscribe(principal, message);
+        GameOutput output = resource.onSubscribe(principal, message, actorTemplateId.toString());
 
         verify(commService).echoToRoom(eq(actor), any(GameOutput.class), eq(actor));
         verify(commService).echo(eq(actor), any(GameOutput.class));
@@ -192,7 +191,7 @@ public class WebSocketResourceTest {
     public void testOnSubscribeReconnectInVoid() {
         when(actor.getGameMap()).thenReturn(null);
 
-        GameOutput output = resource.onSubscribe(principal, message);
+        GameOutput output = resource.onSubscribe(principal, message, actorTemplateId.toString());
 
         verify(commService).echoToRoom(eq(actor), any(GameOutput.class), eq(actor));
         verify(commService).echo(eq(actor), any(GameOutput.class));
@@ -220,7 +219,7 @@ public class WebSocketResourceTest {
         when(gameMapRepository.getOne(eq(defaultMapId))).thenReturn(gameMap);
         when(session.getAttribute(eq("actor_template"))).thenReturn(UUID.randomUUID().toString());
 
-        GameOutput output = resource.onSubscribe(principal, message);
+        GameOutput output = resource.onSubscribe(principal, message, actorTemplateId.toString());
 
         verify(commService).echoToRoom(any(Actor.class), any(GameOutput.class), any(Actor.class));
         verify(invokerService).invoke(any(Actor.class), any(GameOutput.class), isNull(), anyList());
@@ -252,7 +251,7 @@ public class WebSocketResourceTest {
     public void testOnSubscribeNoTemplate() {
         when(playerActorTemplateRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
 
-        resource.onSubscribe(principal, message);
+        resource.onSubscribe(principal, message, actorTemplateId.toString());
     }
 
     @Test


### PR DESCRIPTION
This stops relying on the HTTP session for remembering which character to reconnect as, so your various browser tabs should reconnect to the same characters as you'd expect.

Fixes #79 