### PR TITLE
Fixed broken message dispatching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.agonyengine'
-version '0.9.0-SNAPSHOT'
+version '0.9.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/agonyengine/config/WebSocketBrokerConfiguration.java
+++ b/src/main/java/com/agonyengine/config/WebSocketBrokerConfiguration.java
@@ -1,5 +1,6 @@
 package com.agonyengine.config;
 
+import com.agonyengine.resource.UniqueHandshakeHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.config.StompBrokerRelayRegistration;
@@ -27,24 +28,26 @@ public class WebSocketBrokerConfiguration extends AbstractSessionWebSocketMessag
 
     @Override
     protected void configureStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/mud").withSockJS();
+        registry
+            .addEndpoint("/mud")
+            .setHandshakeHandler(new UniqueHandshakeHandler())
+            .withSockJS();
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry
+        StompBrokerRelayRegistration relayRegistration = registry
             .setApplicationDestinationPrefixes("/app", "/user")
-            .setUserDestinationPrefix("/user");
-
-        StompBrokerRelayRegistration relayRegistration = registry.enableStompBrokerRelay("/queue", "/topic")
-                .setUserDestinationBroadcast("/topic/logbook-unresolved-user")
-                .setUserRegistryBroadcast("/topic/logbook-user-registry")
-                .setRelayHost(brokerProperties.getHost())
-                .setRelayPort(brokerProperties.getPort())
-                .setSystemLogin(brokerProperties.getSystemUsername())
-                .setSystemPasscode(brokerProperties.getSystemPassword())
-                .setClientLogin(brokerProperties.getClientUsername())
-                .setClientPasscode(brokerProperties.getClientPassword());
+            .setUserDestinationPrefix("/user")
+            .enableStompBrokerRelay("/queue", "/topic")
+            .setUserDestinationBroadcast("/topic/user-destination")
+            .setUserRegistryBroadcast("/topic/user-registry")
+            .setRelayHost(brokerProperties.getHost())
+            .setRelayPort(brokerProperties.getPort())
+            .setSystemLogin(brokerProperties.getSystemUsername())
+            .setSystemPasscode(brokerProperties.getSystemPassword())
+            .setClientLogin(brokerProperties.getClientUsername())
+            .setClientPasscode(brokerProperties.getClientPassword());
 
         if (brokerProperties.getSsl()) {
             relayRegistration.setTcpClient(createSslTcpClient());

--- a/src/main/java/com/agonyengine/resource/StompPrincipal.java
+++ b/src/main/java/com/agonyengine/resource/StompPrincipal.java
@@ -1,0 +1,20 @@
+package com.agonyengine.resource;
+
+import java.security.Principal;
+
+/**
+ * Borrowed from:
+ * https://stackoverflow.com/questions/37853727/where-user-comes-from-in-convertandsendtouser-works-in-sockjsspring-websocket?rq=1
+ */
+public class StompPrincipal implements Principal {
+    private String name;
+
+    StompPrincipal(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/agonyengine/resource/UniqueHandshakeHandler.java
+++ b/src/main/java/com/agonyengine/resource/UniqueHandshakeHandler.java
@@ -1,0 +1,20 @@
+package com.agonyengine.resource;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Borrowed from:
+ * https://stackoverflow.com/questions/37853727/where-user-comes-from-in-convertandsendtouser-works-in-sockjsspring-websocket?rq=1
+ */
+public class UniqueHandshakeHandler extends DefaultHandshakeHandler {
+    @Override
+    protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        return new StompPrincipal(UUID.randomUUID().toString());
+    }
+}

--- a/src/main/java/com/agonyengine/resource/WebSocketResource.java
+++ b/src/main/java/com/agonyengine/resource/WebSocketResource.java
@@ -122,17 +122,12 @@ public class WebSocketResource {
 
             commService.echoToRoom(actor, new GameOutput(String.format("[yellow]%s appears in a puff of smoke!", actor.getName())), actor);
 
-            LOGGER.info("{} has connected ({})", actor.getName(), actor.getId());
+            LOGGER.info("{} has connected ({})", actor.getName(), actor.getConnection().getRemoteIpAddress());
         } else {
-            GameOutput reconnect = new GameOutput();
-
-            reconnect.append("[yellow]Your connection has been reconnected in another browser!");
-            reconnect.append("<script type=\"text/javascript\">setTimeout(function() { window.location=\"/account\"; }, 1000);</script>");
-
-            commService.echo(actor, reconnect);
+            commService.echo(actor, handleReconnectedSession(new GameOutput()));
             commService.echoToRoom(actor, new GameOutput(String.format("[yellow]%s has reconnected.", actor.getName())), actor);
 
-            LOGGER.info("{} has reconnected ({})", actor.getName(), actor.getId());
+            LOGGER.info("{} has reconnected ({})", actor.getName(), actor.getConnection().getRemoteIpAddress());
         }
 
         actor.getConnection().setSessionUsername(principal.getName());
@@ -155,8 +150,13 @@ public class WebSocketResource {
     @MessageMapping("/input")
     @SendToUser(value = "/queue/output", broadcast = false)
     public GameOutput onInput(Principal principal, UserInput input, Message<byte[]> message) {
-        Actor actor = actorRepository.findByConnectionSessionUsernameAndConnectionSessionId(principal.getName(), getStompSessionId(message));
         GameOutput output = new GameOutput();
+        Actor actor = actorRepository.findByConnectionSessionUsernameAndConnectionSessionId(principal.getName(), getStompSessionId(message));
+
+        if (actor == null) {
+            return handleReconnectedSession(output);
+        }
+
         List<List<String>> sentences = inputTokenizer.tokenize(input.getInput());
 
         if (sentences.size() > 0) {
@@ -194,5 +194,12 @@ public class WebSocketResource {
         SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(message);
 
         return headerAccessor.getSessionId();
+    }
+
+    private GameOutput handleReconnectedSession(GameOutput output) {
+        output.append("[yellow]Your connection has been reconnected in another browser!");
+        output.append("<script type=\"text/javascript\">setTimeout(function() { window.location=\"/account\"; }, 1000);</script>");
+
+        return output;
     }
 }

--- a/src/main/java/com/agonyengine/resource/WebSocketResource.java
+++ b/src/main/java/com/agonyengine/resource/WebSocketResource.java
@@ -98,6 +98,11 @@ public class WebSocketResource {
             actor.setInventory(inventoryMap);
         }
 
+        actor.getConnection().setSessionUsername(principal.getName());
+        actor.getConnection().setSessionId(getStompSessionId(message));
+        actor.getConnection().setRemoteIpAddress(session.getAttribute("remoteIpAddress"));
+        actor.getConnection().setDisconnectedDate(null);
+
         if (actor.getGameMap() == null) {
             GameMap defaultMap = gameMapRepository.getOne(defaultMapId);
 
@@ -129,11 +134,6 @@ public class WebSocketResource {
 
             LOGGER.info("{} has reconnected ({})", actor.getName(), actor.getConnection().getRemoteIpAddress());
         }
-
-        actor.getConnection().setSessionUsername(principal.getName());
-        actor.getConnection().setSessionId(getStompSessionId(message));
-        actor.getConnection().setRemoteIpAddress(session.getAttribute("remoteIpAddress"));
-        actor.getConnection().setDisconnectedDate(null);
 
         actor = actorRepository.save(actor);
 

--- a/src/main/java/com/agonyengine/service/CommService.java
+++ b/src/main/java/com/agonyengine/service/CommService.java
@@ -3,7 +3,6 @@ package com.agonyengine.service;
 import com.agonyengine.model.actor.Actor;
 import com.agonyengine.model.stomp.GameOutput;
 import com.agonyengine.repository.ActorRepository;
-import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
@@ -27,13 +26,9 @@ public class CommService {
             return;
         }
 
-        SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
-
-        headerAccessor.setSessionId(target.getConnection().getSessionId());
-
         addPrompt(message);
 
-        simpMessagingTemplate.convertAndSendToUser(target.getConnection().getSessionUsername(), "/queue/output", message, headerAccessor.getMessageHeaders());
+        simpMessagingTemplate.convertAndSendToUser(target.getConnection().getSessionUsername(), "/queue/output", message);
     }
 
     public void echoToRoom(Actor source, GameOutput message, Actor... exclude) {
@@ -45,13 +40,7 @@ public class CommService {
             .stream()
             .filter(t -> t.getConnection() != null)
             .filter(t -> !excludeList.contains(t))
-            .forEach(t -> {
-                SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
-
-                headerAccessor.setSessionId(t.getConnection().getSessionId());
-
-                simpMessagingTemplate.convertAndSendToUser(t.getConnection().getSessionUsername(), "/queue/output", message, headerAccessor.getMessageHeaders());
-            });
+            .forEach(t -> simpMessagingTemplate.convertAndSendToUser(t.getConnection().getSessionUsername(), "/queue/output", message));
     }
 
     private void addPrompt(GameOutput output) {

--- a/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
+++ b/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
@@ -300,6 +300,17 @@ public class WebSocketResourceTest {
     }
 
     @Test
+    public void testOnInputReconnected() {
+        when(actorRepository.findByConnectionSessionUsernameAndConnectionSessionId(any(), any())).thenReturn(null);
+
+        GameOutput output = resource.onInput(principal, input, message);
+
+        verify(inputTokenizer, never()).tokenize(any());
+
+        assertTrue(output.getOutput().stream().anyMatch(line -> line.contains("another browser")));
+    }
+
+    @Test
     public void testOnInputMultipleSentences() {
         UUID actorId = UUID.randomUUID();
 

--- a/src/test/java/com/agonyengine/service/CommServiceTest.java
+++ b/src/test/java/com/agonyengine/service/CommServiceTest.java
@@ -6,22 +6,17 @@ import com.agonyengine.model.stomp.GameOutput;
 import com.agonyengine.repository.ActorRepository;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
-import static org.springframework.messaging.simp.SimpMessageHeaderAccessor.SESSION_ID_HEADER;
 
 public class CommServiceTest {
     @Mock
@@ -38,9 +33,6 @@ public class CommServiceTest {
 
     @Mock
     private GameOutput output;
-
-    @Captor
-    private ArgumentCaptor<MessageHeaders> messageHeadersCaptor;
 
     private List<Actor> observers = new ArrayList<>();
 
@@ -78,13 +70,8 @@ public class CommServiceTest {
         verify(simpMessagingTemplate).convertAndSendToUser(
             eq("sessionUsername"),
             eq("/queue/output"),
-            eq(output),
-            messageHeadersCaptor.capture()
+            eq(output)
         );
-
-        MessageHeaders headers = messageHeadersCaptor.getValue();
-
-        assertEquals("sessionId", headers.get(SESSION_ID_HEADER));
     }
 
     @Test
@@ -95,35 +82,25 @@ public class CommServiceTest {
         verify(simpMessagingTemplate, never()).convertAndSendToUser(
             eq("sessionUsername"),
             eq("/queue/output"),
-            eq(output),
-            any(MessageHeaders.class)
+            eq(output)
         );
 
         verify(simpMessagingTemplate).convertAndSendToUser(
             eq("sessionUser-0"),
             eq("/queue/output"),
-            eq(output),
-            messageHeadersCaptor.capture()
+            eq(output)
         );
 
         verify(simpMessagingTemplate).convertAndSendToUser(
             eq("sessionUser-1"),
             eq("/queue/output"),
-            eq(output),
-            messageHeadersCaptor.capture()
+            eq(output)
         );
 
         verify(simpMessagingTemplate).convertAndSendToUser(
             eq("sessionUser-2"),
             eq("/queue/output"),
-            eq(output),
-            messageHeadersCaptor.capture()
+            eq(output)
         );
-
-        List<MessageHeaders> headers = messageHeadersCaptor.getAllValues();
-
-        assertEquals("sessionId-0", headers.get(0).get(SESSION_ID_HEADER));
-        assertEquals("sessionId-1", headers.get(1).get(SESSION_ID_HEADER));
-        assertEquals("sessionId-2", headers.get(2).get(SESSION_ID_HEADER));
     }
 }


### PR DESCRIPTION
When trying to send messages from one application instance to the other over the broker, they were instead getting dropped. I had borrowed some code from EmergentMUD that set a session ID in the header of every message, which works great when there is a single application server. Removing the headers made the messages successfully travel between application servers, but when two tabs were logged in on the same account both tabs would get messages not intended for them; Spring can send messages to a /user/ but not so easily to a specific /session/.

The solution I eventually landed on was to stop setting the headers on the messages, and to implement UniqueHandshakeHandler which produces Principals with random UUIDs as usernames. Now that the users are all unique, Spring can send messages to individual characters without bleeding over into other tabs!