### PR TITLE
Triggered NPE trying to make items LOOK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.agonyengine'
-version '0.12.0-SNAPSHOT'
+version '0.12.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/agonyengine/model/command/GetCommand.java
+++ b/src/main/java/com/agonyengine/model/command/GetCommand.java
@@ -30,7 +30,7 @@ public class GetCommand {
 
     @Transactional
     public void invoke(Actor actor, GameOutput output, ActorSameRoom itemBinding) {
-        if (!actor.getCreatureInfo().hasCapability(HOLD)) {
+        if (actor.getCreatureInfo() == null || !actor.getCreatureInfo().hasCapability(HOLD)) {
             output.append("[default]Alas, you are unable to hold items.");
             return;
         }

--- a/src/main/java/com/agonyengine/model/command/LookCommand.java
+++ b/src/main/java/com/agonyengine/model/command/LookCommand.java
@@ -41,7 +41,7 @@ public class LookCommand {
     @Transactional
     public void invoke(Actor actor, GameOutput output) {
         // TODO could commands declare the capabilities they require via an annotation, so that the invoker could perform this check?
-        if (!actor.getCreatureInfo().hasCapability(SEE)) {
+        if (actor.getCreatureInfo() == null || !actor.getCreatureInfo().hasCapability(SEE)) {
             output.append("[default]Alas, you are unable to see.");
             return;
         }

--- a/src/main/java/com/agonyengine/model/command/MoveCommand.java
+++ b/src/main/java/com/agonyengine/model/command/MoveCommand.java
@@ -40,7 +40,7 @@ public class MoveCommand {
     @Transactional
     public void invoke(Actor actor, GameOutput output) {
         // TODO could commands declare the capabilities they require via an annotation, so that the invoker could perform this check?
-        if (!actor.getCreatureInfo().hasCapability(WALK)) {
+        if (actor.getCreatureInfo() == null || !actor.getCreatureInfo().hasCapability(WALK)) {
             output.append("[default]Alas, you are unable to walk.");
             return;
         }

--- a/src/main/java/com/agonyengine/model/command/SayCommand.java
+++ b/src/main/java/com/agonyengine/model/command/SayCommand.java
@@ -23,7 +23,7 @@ public class SayCommand {
 
     @Transactional
     public void invoke(Actor actor, GameOutput output, QuotedString message) {
-        if (!actor.getCreatureInfo().hasCapability(SPEAK)) {
+        if (actor.getCreatureInfo() == null || !actor.getCreatureInfo().hasCapability(SPEAK)) {
             output.append("[default]Alas, you are unable to speak.");
             return;
         }

--- a/src/test/java/com/agonyengine/model/command/GetCommandTest.java
+++ b/src/test/java/com/agonyengine/model/command/GetCommandTest.java
@@ -1,0 +1,55 @@
+package com.agonyengine.model.command;
+
+import com.agonyengine.model.actor.Actor;
+import com.agonyengine.model.interpret.ActorSameRoom;
+import com.agonyengine.model.stomp.GameOutput;
+import com.agonyengine.repository.ActorRepository;
+import com.agonyengine.service.CommService;
+import com.agonyengine.service.InvokerService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.verify;
+
+public class GetCommandTest {
+    @Mock
+    private Actor actor;
+
+    @Mock
+    private GameOutput output;
+
+    @Mock
+    private ActorSameRoom actorSameRoom;
+
+    @Mock
+    private CommService commService;
+
+    @Mock
+    private InvokerService invokerService;
+
+    @Mock
+    private ActorRepository actorRepository;
+
+    private GetCommand getCommand;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        getCommand = new GetCommand(
+            commService,
+            invokerService,
+            actorRepository
+        );
+    }
+
+    @Test
+    public void testInvokeNonCreature() {
+        getCommand.invoke(actor, output, actorSameRoom);
+
+        verify(output).append(contains("Alas"));
+    }
+}

--- a/src/test/java/com/agonyengine/model/command/LookCommandTest.java
+++ b/src/test/java/com/agonyengine/model/command/LookCommandTest.java
@@ -1,0 +1,57 @@
+package com.agonyengine.model.command;
+
+import com.agonyengine.model.actor.Actor;
+import com.agonyengine.model.stomp.GameOutput;
+import com.agonyengine.repository.ActorRepository;
+import com.agonyengine.repository.ExitRepository;
+import com.agonyengine.service.CommService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.verify;
+
+public class LookCommandTest {
+    @Mock
+    private Actor actor;
+
+    @Mock
+    private GameOutput output;
+
+    @Mock
+    private ExitRepository exitRepository;
+
+    @Mock
+    private ActorRepository actorRepository;
+
+    @Mock
+    private CommService commService;
+
+    private List<Direction> directions = new ArrayList<>();
+
+    private LookCommand lookCommand;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        lookCommand = new LookCommand(
+            exitRepository,
+            actorRepository,
+            commService,
+            directions
+        );
+    }
+
+    @Test
+    public void testInvokeNonCreature() {
+        lookCommand.invoke(actor, output);
+
+        verify(output).append(contains("Alas"));
+    }
+}

--- a/src/test/java/com/agonyengine/model/command/MoveCommandTest.java
+++ b/src/test/java/com/agonyengine/model/command/MoveCommandTest.java
@@ -105,6 +105,15 @@ public class MoveCommandTest {
     }
 
     @Test
+    public void testInvokeNonCreature() {
+        when(actor.getCreatureInfo()).thenReturn(null);
+
+        moveCommand.invoke(actor, output);
+
+        verify(output).append(contains("Alas"));
+    }
+
+    @Test
     public void testExit() {
         GameMap map = new GameMap();
         Exit exit = new Exit();

--- a/src/test/java/com/agonyengine/model/command/SayCommandTest.java
+++ b/src/test/java/com/agonyengine/model/command/SayCommandTest.java
@@ -1,0 +1,43 @@
+package com.agonyengine.model.command;
+
+import com.agonyengine.model.actor.Actor;
+import com.agonyengine.model.interpret.QuotedString;
+import com.agonyengine.model.stomp.GameOutput;
+import com.agonyengine.service.CommService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.verify;
+
+public class SayCommandTest {
+    @Mock
+    private Actor actor;
+
+    @Mock
+    private GameOutput output;
+
+    @Mock
+    private QuotedString quotedString;
+
+    @Mock
+    private CommService commService;
+
+    private SayCommand sayCommand;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        sayCommand = new SayCommand(commService);
+    }
+
+    @Test
+    public void testInvokeNonCreature() {
+        sayCommand.invoke(actor, output, quotedString);
+
+        verify(output).append(contains("Alas"));
+    }
+}


### PR DESCRIPTION
The LOOK command didn't check for actor.getCreatureInfo() being null before dereferencing it. GET and DROP make the Actor that was picked up or dropped execute a LOOK. Most of the time it's wasted effort since it's just an item but when it's a player it makes everything look right. When it was not a player, there was no CreatureInfo attached to the Actor and it threw the NPE. I somewhat over-aggressively added tests and null checks to prevent this from happening.