### PR TITLE
Enum indexes

### DIFF
--- a/src/main/java/com/agonyengine/model/actor/BodyPartCapability.java
+++ b/src/main/java/com/agonyengine/model/actor/BodyPartCapability.java
@@ -1,21 +1,29 @@
 package com.agonyengine.model.actor;
 
 import com.agonyengine.model.converter.BaseEnumSetConverter;
+import com.agonyengine.model.converter.PersistentEnum;
 
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.stream.Collectors;
 
-public enum BodyPartCapability {
-    SPEAK("speak"),
-    WALK("walk"),
-    HOLD("hold items"),
-    SEE("see");
+public enum BodyPartCapability implements PersistentEnum {
+    SPEAK(0, "speak"),
+    WALK(1, "walk"),
+    HOLD(2, "hold items"),
+    SEE(3, "see");
 
+    private int index;
     private String description;
 
-    BodyPartCapability(String description) {
+    BodyPartCapability(int index, String description) {
+        this.index = index;
         this.description = description;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
     }
 
     public String getDescription() {

--- a/src/main/java/com/agonyengine/model/actor/TileFlag.java
+++ b/src/main/java/com/agonyengine/model/actor/TileFlag.java
@@ -1,9 +1,21 @@
 package com.agonyengine.model.actor;
 
 import com.agonyengine.model.converter.BaseEnumSetConverter;
+import com.agonyengine.model.converter.PersistentEnum;
 
-public enum TileFlag {
-    IMPASSABLE;
+public enum TileFlag implements PersistentEnum {
+    IMPASSABLE(0);
+
+    private int index;
+
+    TileFlag(int index) {
+        this.index = index;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
+    }
 
     public static class Converter extends BaseEnumSetConverter<TileFlag> {
         public Converter() {

--- a/src/main/java/com/agonyengine/model/actor/WearLocation.java
+++ b/src/main/java/com/agonyengine/model/actor/WearLocation.java
@@ -1,20 +1,32 @@
 package com.agonyengine.model.actor;
 
 import com.agonyengine.model.converter.BaseEnumSetConverter;
+import com.agonyengine.model.converter.PersistentEnum;
 
-public enum WearLocation {
-    HEAD,
-    NECK,
-    WRIST,
-    HAND,
-    FINGER,
-    FOOT,
-    BODY_UPPER,
-    BODY_LOWER,
-    ARM_UPPER,
-    ARM_LOWER,
-    LEG_UPPER,
-    LEG_LOWER;
+public enum WearLocation implements PersistentEnum {
+    HEAD(0),
+    NECK(1),
+    WRIST(2),
+    HAND(3),
+    FINGER(4),
+    FOOT(5),
+    BODY_UPPER(6),
+    BODY_LOWER(7),
+    ARM_UPPER(8),
+    ARM_LOWER(9),
+    LEG_UPPER(10),
+    LEG_LOWER(11);
+
+    private int index;
+
+    WearLocation(int index) {
+        this.index = index;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
+    }
 
     public static class Converter extends BaseEnumSetConverter<WearLocation> {
         public Converter() {

--- a/src/main/java/com/agonyengine/model/converter/PersistentEnum.java
+++ b/src/main/java/com/agonyengine/model/converter/PersistentEnum.java
@@ -1,0 +1,5 @@
+package com.agonyengine.model.converter;
+
+public interface PersistentEnum {
+    int getIndex();
+}

--- a/src/test/java/com/agonyengine/model/actor/BodyPartCapabilityTest.java
+++ b/src/test/java/com/agonyengine/model/actor/BodyPartCapabilityTest.java
@@ -11,6 +11,16 @@ import static org.junit.Assert.assertEquals;
 
 public class BodyPartCapabilityTest {
     @Test
+    public void testIndex() {
+        assertEquals(0, SPEAK.getIndex());
+    }
+
+    @Test
+    public void testConverter() {
+        new BodyPartCapability.Converter();
+    }
+
+    @Test
     public void testDescription() {
         assertEquals("speak", SPEAK.getDescription());
     }

--- a/src/test/java/com/agonyengine/model/actor/TileFlagTest.java
+++ b/src/test/java/com/agonyengine/model/actor/TileFlagTest.java
@@ -1,0 +1,17 @@
+package com.agonyengine.model.actor;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TileFlagTest {
+    @Test
+    public void testIndex() {
+        assertEquals(0, TileFlag.IMPASSABLE.getIndex());
+    }
+
+    @Test
+    public void testConverter() {
+        new TileFlag.Converter();
+    }
+}

--- a/src/test/java/com/agonyengine/model/actor/WearLocationTest.java
+++ b/src/test/java/com/agonyengine/model/actor/WearLocationTest.java
@@ -1,0 +1,17 @@
+package com.agonyengine.model.actor;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class WearLocationTest {
+    @Test
+    public void testIndex() {
+        assertEquals(0, WearLocation.HEAD.getIndex());
+    }
+
+    @Test
+    public void testConverter() {
+        new WearLocation.Converter();
+    }
+}

--- a/src/test/java/com/agonyengine/model/converter/BaseEnumSetConverterTest.java
+++ b/src/test/java/com/agonyengine/model/converter/BaseEnumSetConverterTest.java
@@ -1,0 +1,42 @@
+package com.agonyengine.model.converter;
+
+import org.junit.Test;
+
+import java.util.EnumSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BaseEnumSetConverterTest {
+    private Converter converter = new Converter();
+
+    @Test
+    public void testPersist() {
+        EnumSet<TestPersistentEnum> testEnumSet = EnumSet.of(
+            TestPersistentEnum.ABLE,
+            TestPersistentEnum.EASY);
+
+        long result = converter.convertToDatabaseColumn(testEnumSet);
+
+        assertEquals(0b10001, result);
+    }
+
+    @Test
+    public void testRestore() {
+        EnumSet<TestPersistentEnum> result = converter.convertToEntityAttribute((long)0b10001);
+
+        assertTrue(result.contains(TestPersistentEnum.ABLE));
+        assertFalse(result.contains(TestPersistentEnum.BAKER));
+        assertFalse(result.contains(TestPersistentEnum.CHARLIE));
+        assertFalse(result.contains(TestPersistentEnum.DOG));
+        assertTrue(result.contains(TestPersistentEnum.EASY));
+
+    }
+
+    public static class Converter extends BaseEnumSetConverter<TestPersistentEnum> {
+        Converter() {
+            super(TestPersistentEnum.class);
+        }
+    }
+}

--- a/src/test/java/com/agonyengine/model/converter/TestPersistentEnum.java
+++ b/src/test/java/com/agonyengine/model/converter/TestPersistentEnum.java
@@ -1,0 +1,20 @@
+package com.agonyengine.model.converter;
+
+public enum TestPersistentEnum implements PersistentEnum {
+    ABLE(0),
+    BAKER(1),
+    CHARLIE(2),
+    DOG(3),
+    EASY(4);
+
+    private int index;
+
+    TestPersistentEnum(int index) {
+        this.index = index;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
+    }
+}


### PR DESCRIPTION
The Apache `EnumUtils` used enum ordinals, which can shift unexpectedly when you add or subtract values from an enum. This change adds a `PersistentEnum` interface that offers a `getIndex()` method. The index can be set any way, but the pattern I have in mind is that you specify it in the enum's constructor. That way it will be very obvious what the value is and it will never change unless you change it yourself. That should help to avoid accidentally corrupting the database by adding new enums. The downside is that the converter can only convert `PersistentEnum`s now, so you have to be deliberate when building your model classes.