### PR TITLE
Tile Flags

### DIFF
--- a/src/main/java/com/agonyengine/model/actor/TileFlag.java
+++ b/src/main/java/com/agonyengine/model/actor/TileFlag.java
@@ -4,7 +4,8 @@ import com.agonyengine.model.converter.BaseEnumSetConverter;
 import com.agonyengine.model.converter.PersistentEnum;
 
 public enum TileFlag implements PersistentEnum {
-    IMPASSABLE(0);
+    IMPASSABLE(0),
+    WILDERNESS(1);
 
     private int index;
 

--- a/src/main/java/com/agonyengine/model/command/LookCommand.java
+++ b/src/main/java/com/agonyengine/model/command/LookCommand.java
@@ -2,7 +2,7 @@ package com.agonyengine.model.command;
 
 import com.agonyengine.model.actor.Actor;
 import com.agonyengine.model.actor.Tile;
-import com.agonyengine.model.actor.Tileset;
+import com.agonyengine.model.actor.TileFlag;
 import com.agonyengine.model.interpret.ActorSameRoom;
 import com.agonyengine.model.stomp.GameOutput;
 import com.agonyengine.repository.ActorRepository;
@@ -58,7 +58,9 @@ public class LookCommand {
 
         output.append(directions.stream()
             .filter(direction -> exitRepository.findByDirectionAndLocationGameMapAndLocationXAndLocationY(direction.getName(), actor.getGameMap(), actor.getX(), actor.getY()) != null
-                || actor.getGameMap().hasTile(actor.getX() + direction.getX(), actor.getY() + direction.getY()))
+                || (actor.getGameMap().hasTile(actor.getX() + direction.getX(), actor.getY() + direction.getY())
+                    && !(actor.getGameMap().getTile(actor.getX() + direction.getX(), actor.getY() + direction.getY()).getFlags().contains(TileFlag.IMPASSABLE)))
+            )
             .map(Direction::getName)
             .collect(joining(" ", "[cyan]Exits: ", "")));
 

--- a/src/main/java/com/agonyengine/model/command/MoveCommand.java
+++ b/src/main/java/com/agonyengine/model/command/MoveCommand.java
@@ -1,6 +1,7 @@
 package com.agonyengine.model.command;
 
 import com.agonyengine.model.actor.Actor;
+import com.agonyengine.model.actor.TileFlag;
 import com.agonyengine.model.exit.Exit;
 import com.agonyengine.model.stomp.GameOutput;
 import com.agonyengine.repository.ActorRepository;
@@ -53,7 +54,7 @@ public class MoveCommand {
             newX = actor.getX() + direction.getX();
             newY = actor.getY() + direction.getY();
 
-            if (!actor.getGameMap().hasTile(newX, newY)) {
+            if (!actor.getGameMap().hasTile(newX, newY) || actor.getGameMap().getTile(newX, newY).getFlags().contains(TileFlag.IMPASSABLE)) {
                 output.append("[default]Alas, you cannot go that way.");
                 return;
             }

--- a/src/main/resources/db/migration/R__0003_tilesets.sql
+++ b/src/main/resources/db/migration/R__0003_tilesets.sql
@@ -1,31 +1,29 @@
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-
 INSERT INTO tileset (id, name)
 VALUES ('e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'The Temple') ON CONFLICT (id) DO
 UPDATE SET name=EXCLUDED.name;
 
 INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
-VALUES (uuid_generate_v4(), 0, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'The Origin', 'A building of smooth polished stones has been constructed around a circular spot on the floor. A white glow emanates from the spot, radiating glowing particles up into the air.', 0) ON CONFLICT (id) DO
+VALUES ('3e4d15e1-27b4-402f-a160-7c9758c9ca04', 0, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'The Origin', 'A building of smooth polished stones has been constructed around a circular spot on the floor. A white glow emanates from the spot, radiating glowing particles up into the air.', 0) ON CONFLICT (id) DO
 UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
 
 INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
-VALUES (uuid_generate_v4(), 1, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Colonnade', 'The covered colonnade is built from smooth polished stone. The open sides look out into the evergreen forest beyond, providing only minimal protection from the elements.', 0) ON CONFLICT (id) DO
+VALUES ('ce38de4f-b5d5-4b76-bbb3-98f46c03557c', 1, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Colonnade', 'The covered colonnade is built from smooth polished stone. The open sides look out into the evergreen forest beyond, providing only minimal protection from the elements.', 0) ON CONFLICT (id) DO
 UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
 
 INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
-VALUES (uuid_generate_v4(), 2, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Vestibule', 'This small vestibule serves as a place for visitors to remove their wet or dirty clothing before proceeding further into the temple. ', 0) ON CONFLICT (id) DO
+VALUES ('4b50f352-ef71-4fc0-a8d6-b237bc30bf5d', 2, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Vestibule', 'This small vestibule serves as a place for visitors to remove their wet or dirty clothing before proceeding further into the temple. ', 0) ON CONFLICT (id) DO
 UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
 
 INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
-VALUES (uuid_generate_v4(), 3, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Courtyard', 'A small, but carefully maintained courtyard contains many examples of the local flora, arranged beautifully by some master gardener.', 0) ON CONFLICT (id) DO
+VALUES ('bca5bbea-1431-40ab-b7a7-89ea68381034', 3, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Courtyard', 'A small, but carefully maintained courtyard contains many examples of the local flora, arranged beautifully by some master gardener.', 0) ON CONFLICT (id) DO
 UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
 
 INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
-VALUES (uuid_generate_v4(), 4, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Armory', 'Weapon and armor racks line the walls, and a practice dummy stands forlornly in the corner.', 0) ON CONFLICT (id) DO
+VALUES ('23355f3d-1e43-4c84-88db-fc7d25e4d869', 4, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Armory', 'Weapon and armor racks line the walls, and a practice dummy stands forlornly in the corner.', 0) ON CONFLICT (id) DO
 UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
 
 INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
-VALUES (uuid_generate_v4(), 5, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Lounge', 'Several couches and overstuffed chairs have been arranged here, offering comfort to weary travellers.', 0) ON CONFLICT (id) DO
+VALUES ('6ad8680b-1539-429a-b6c8-6d86e8465088', 5, 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be', 'Lounge', 'Several couches and overstuffed chairs have been arranged here, offering comfort to weary travellers.', 0) ON CONFLICT (id) DO
 UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
 
 INSERT INTO tileset (id, name)
@@ -33,7 +31,23 @@ VALUES ('6b9cdb5b-0560-4dde-b40b-89dd1b928844', 'Temperate Rain Forest') ON CONF
 UPDATE SET name=EXCLUDED.name;
 
 INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
-VALUES (uuid_generate_v4(), 0, '6b9cdb5b-0560-4dde-b40b-89dd1b928844', 'Temperate Rain Forest', 'Dark, somber evergreen trees make up this thick forest.', 0) ON CONFLICT (id) DO
+VALUES ('ff6d419e-35ff-441a-8d52-15ec048fdbf9', 0, '6b9cdb5b-0560-4dde-b40b-89dd1b928844', 'Impassable', 'This room is impassable, and not actually part of the map. What are you doing here?', 1) ON CONFLICT (id) DO
+UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
+
+INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
+VALUES ('1d50bc5f-1eda-41ac-8cc5-97614c5c6f8f', 1, '6b9cdb5b-0560-4dde-b40b-89dd1b928844', 'A Clearing', 'The trees give way here to an open space, offering a view of the sky and less obstructed movement.', 2) ON CONFLICT (id) DO
+UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
+
+INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
+VALUES ('b9dcfdce-fcb5-47d2-a3fe-ffa7338a3c75', 2, '6b9cdb5b-0560-4dde-b40b-89dd1b928844', 'Light Evergreen Forest', 'Large old growth evergreen trees make up the forest here, spaced widely apart. There is very little undergrowth. The forest floor is primarily just a bed of red and orange pine needles.', 2) ON CONFLICT (id) DO
+UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
+
+INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
+VALUES ('950cadef-b7ce-4e37-92f9-a6be747ae03d', 3, '6b9cdb5b-0560-4dde-b40b-89dd1b928844', 'Evergreen Forest', 'Large evergreen trees thrive here, their thick boughs blocking any sunlight. The trunks grow fairly close to one another, but the darkness and acidity have choked out most smaller trees and shrubs. Patches of ivy are all the plant life that can survive beneath these behemoths.', 2) ON CONFLICT (id) DO
+UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
+
+INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
+VALUES ('bb698d2f-2d69-448c-92f2-1abe8874e3b2', 4, '6b9cdb5b-0560-4dde-b40b-89dd1b928844', 'Dense Evergreen Forest', 'A tangle of young to medium sized evergreen trees makes up the forest here. Vines and shrubs grow between them, sucking up any rays of light that shine through the canopy and drawing nutrients from the larger trees themselves. Movement is made quite difficult in some places by the encroaching vines and branches.', 2) ON CONFLICT (id) DO
 UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;
 
 INSERT INTO tileset (id, name)
@@ -41,5 +55,5 @@ VALUES ('429a3d68-7658-47b0-bba7-8a1d52fb097e', 'Inside Someone''s Inventory') O
 UPDATE SET name=EXCLUDED.name;
 
 INSERT INTO tile (id, index, tileset, room_title, room_description, flags)
-VALUES (uuid_generate_v4(), 0, '429a3d68-7658-47b0-bba7-8a1d52fb097e', 'Carried', 'You are being carried by someone.', 0) ON CONFLICT (id) DO
+VALUES ('c825d1c5-1930-46f7-9b03-2eb7b891f049', 0, '429a3d68-7658-47b0-bba7-8a1d52fb097e', 'Carried', 'You are being carried by someone.', 0) ON CONFLICT (id) DO
 UPDATE SET tileset=EXCLUDED.tileset, room_title=EXCLUDED.room_title, flags=EXCLUDED.flags;

--- a/src/main/resources/db/migration/R__0004_maps.sql
+++ b/src/main/resources/db/migration/R__0004_maps.sql
@@ -3,7 +3,7 @@ VALUES ('5231e20f-0658-4685-9396-6e69ebfb2c3b', 3, decode('000102010301040105', 
 UPDATE SET width=EXCLUDED.width, tiles=EXCLUDED.tiles, tileset_id=EXCLUDED.tileset_id;
 
 INSERT INTO game_map (id, width, tiles, tileset_id)
-VALUES ('a70bdd6f-b2a3-451e-aed2-90d1fe37f0dd', 5, decode('00000000000000000000000000000000000000000000000000', 'hex'), '6b9cdb5b-0560-4dde-b40b-89dd1b928844') ON CONFLICT (id) DO
+VALUES ('a70bdd6f-b2a3-451e-aed2-90d1fe37f0dd', 5, decode('01020304010203040102030401020304010203040102030400', 'hex'), '6b9cdb5b-0560-4dde-b40b-89dd1b928844') ON CONFLICT (id) DO
 UPDATE SET width=EXCLUDED.width, tiles=EXCLUDED.tiles, tileset_id=EXCLUDED.tileset_id;
 
 INSERT INTO exit (id, direction, location_map_id, location_x, location_y, destination_map_id, destination_x, destination_y)


### PR DESCRIPTION
* Added IMPASSABLE flag that makes a tile act as if it's not part of the map.
* Added WILDERNESS flag which is currently unused, but the map generator will use it to select tiles for "flood fill" operation.
* Removed random UUID generation from tileset SQL, which would have caused duplicate entries. Glad I caught that!
* Added more forest tiles.
* Forest map now has a variety of different tiles in it.