### PR TITLE
Versioning scheme for maps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.agonyengine'
-version '0.12.3-SNAPSHOT'
+version '0.12.4-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/agonyengine/model/actor/GameMap.java
+++ b/src/main/java/com/agonyengine/model/actor/GameMap.java
@@ -13,12 +13,16 @@ import java.util.UUID;
 
 @Entity
 public class GameMap {
+    public static final int CURRENT_MAP_VERSION = 1;
+    public static final int NO_UPDATE_VERSION = -1;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(GameMap.class);
 
     @Id
     @GeneratedValue
     @Type(type = "pg-uuid")
     private UUID id;
+    private int version;
     private int width;
     private byte[] tiles;
 
@@ -40,6 +44,14 @@ public class GameMap {
 
     public void setId(UUID id) {
         this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
     }
 
     public int getWidth() {

--- a/src/main/java/com/agonyengine/model/generator/MapGenerator.java
+++ b/src/main/java/com/agonyengine/model/generator/MapGenerator.java
@@ -6,6 +6,8 @@ import com.agonyengine.model.actor.TileFlag;
 import com.agonyengine.model.actor.Tileset;
 import com.agonyengine.repository.GameMapRepository;
 import com.agonyengine.repository.TileRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -14,8 +16,12 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
+import static com.agonyengine.model.actor.GameMap.CURRENT_MAP_VERSION;
+import static com.agonyengine.model.actor.GameMap.NO_UPDATE_VERSION;
+
 @Component
 public class MapGenerator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MapGenerator.class);
     private static final int MAP_ADDITIONAL_WIDTH = 15;
 
     static final int MAP_MIN_WIDTH = 10;
@@ -44,26 +50,80 @@ public class MapGenerator {
     }
 
     public GameMap generateMap(Tileset tileset) {
-        int width = MAP_MIN_WIDTH + RANDOM.nextInt(MAP_ADDITIONAL_WIDTH);
-        GameMap map = new GameMap(width, new byte[width * width]);
+        GameMap map = createBlankMap(tileset);
 
-        map.setTileset(tileset);
-        floodFill(map, tileset);
+        List<Tile> wilderness = findTilesByFlag(map.getTileset(), TileFlag.WILDERNESS);
+        List<Tile> impassable = findTilesByFlag(map.getTileset(), TileFlag.IMPASSABLE);
+
+        floodFill(map, wilderness);
+
+        map.setVersion(CURRENT_MAP_VERSION);
 
         return gameMapRepository.save(map);
     }
 
-    private void floodFill(GameMap map, Tileset tileset) {
-        List<Tile> tiles = tileRepository.findByTileset(tileset);
-        List<Tile> wilderness = tiles.stream()
-            .filter(tile -> tile.getFlags().contains(TileFlag.WILDERNESS))
-            .collect(Collectors.toList());
+    public GameMap updateMap(GameMap map) {
+        if (map.getVersion() == CURRENT_MAP_VERSION || map.getVersion() == NO_UPDATE_VERSION) {
+            return map;
+        }
 
+        LOGGER.info("Updating map {} from version {} to {}", map.getId(), map.getVersion(), CURRENT_MAP_VERSION);
+
+        List<Tile> wilderness = findTilesByFlag(map.getTileset(), TileFlag.WILDERNESS);
+        List<Tile> impassable = findTilesByFlag(map.getTileset(), TileFlag.IMPASSABLE);
+
+        floodFill(map, wilderness);
+
+        map.setVersion(CURRENT_MAP_VERSION);
+
+        return gameMapRepository.save(map);
+    }
+
+    GameMap createBlankMap(Tileset tileset) {
+        int width = MAP_MIN_WIDTH + RANDOM.nextInt(MAP_ADDITIONAL_WIDTH);
+        GameMap map = new GameMap(width, new byte[width * width]);
+
+        map.setTileset(tileset);
+
+        return map;
+    }
+
+    void floodFill(GameMap map, List<Tile> tiles) {
         for (int x = 0; x < map.getWidth(); x++) {
             for (int y = 0; y < map.getWidth(); y++) {
-                Collections.shuffle(wilderness);
-                map.setTile(x, y, (byte)wilderness.get(0).getIndex());
+                Collections.shuffle(tiles);
+                map.setTile(x, y, (byte)tiles.get(0).getIndex());
             }
         }
+    }
+
+    void drawSquare(GameMap map, Tile tile, int centerX, int centerY, int radius) {
+        for (int x = centerX - radius; x <= centerX + radius; x++) {
+            for (int y = centerY - radius; y <= centerY + radius; y++) {
+                map.setTile(x, y, (byte)tile.getIndex());
+            }
+        }
+    }
+
+    void drawCircle(GameMap map, Tile tile, int centerX, int centerY, int radius) {
+        for (int x = centerX - radius; x <= centerX + radius; x++) {
+            for (int y = centerY - radius; y <= centerY + radius; y++) {
+                if (distance(centerX, centerY, x, y) <= radius) {
+                    map.setTile(x, y, (byte) tile.getIndex());
+                }
+            }
+        }
+    }
+
+    private List<Tile> findTilesByFlag(Tileset tileset, TileFlag flag) {
+        List<Tile> tiles = tileRepository.findByTileset(tileset);
+
+        return tiles.stream()
+            .filter(tile -> tile.getFlags().contains(flag))
+            .collect(Collectors.toList());
+    }
+
+    double distance(double x1, double y1, double x2, double y2) {
+        return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
     }
 }

--- a/src/main/java/com/agonyengine/resource/WebSocketResource.java
+++ b/src/main/java/com/agonyengine/resource/WebSocketResource.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.agonyengine.model.actor.GameMap.NO_UPDATE_VERSION;
+
 @Controller
 public class WebSocketResource {
     static final String SPRING_SESSION_ID_KEY = "SPRING.SESSION.ID";
@@ -103,8 +105,9 @@ public class WebSocketResource {
         if (actor.getInventory() == null) {
             GameMap inventoryMap = new GameMap();
 
+            inventoryMap.setVersion(NO_UPDATE_VERSION);
             inventoryMap.setWidth(1);
-            inventoryMap.setTiles(new byte[] { (byte)0xFF });
+            inventoryMap.setTiles(new byte[] { (byte)0x00 });
             inventoryMap.setTileset(tilesetRepository.getOne(inventoryTilesetId));
 
             inventoryMap = gameMapRepository.save(inventoryMap);

--- a/src/main/resources/db/migration/R__0004_maps.sql
+++ b/src/main/resources/db/migration/R__0004_maps.sql
@@ -1,10 +1,10 @@
-INSERT INTO game_map (id, width, tiles, tileset_id)
-VALUES ('5231e20f-0658-4685-9396-6e69ebfb2c3b', 3, decode('000102010301040105', 'hex'), 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be') ON CONFLICT (id) DO
-UPDATE SET width=EXCLUDED.width, tiles=EXCLUDED.tiles, tileset_id=EXCLUDED.tileset_id;
+INSERT INTO game_map (id, version, width, tiles, tileset_id)
+VALUES ('5231e20f-0658-4685-9396-6e69ebfb2c3b', 1, 3, decode('000102010301040105', 'hex'), 'e75bb6e1-a6e9-45cf-bfb4-a9eea1e3b4be') ON CONFLICT (id) DO
+UPDATE SET version=EXCLUDED.version, width=EXCLUDED.width, tiles=EXCLUDED.tiles, tileset_id=EXCLUDED.tileset_id;
 
-INSERT INTO game_map (id, width, tiles, tileset_id)
-VALUES ('a70bdd6f-b2a3-451e-aed2-90d1fe37f0dd', 5, decode('01020304010203040102030401020304010203040102030400', 'hex'), '6b9cdb5b-0560-4dde-b40b-89dd1b928844') ON CONFLICT (id) DO
-UPDATE SET width=EXCLUDED.width, tiles=EXCLUDED.tiles, tileset_id=EXCLUDED.tileset_id;
+INSERT INTO game_map (id, version, width, tiles, tileset_id)
+VALUES ('a70bdd6f-b2a3-451e-aed2-90d1fe37f0dd', 1, 5, decode('01020304010203040102030401020304010203040102030400', 'hex'), '6b9cdb5b-0560-4dde-b40b-89dd1b928844') ON CONFLICT (id) DO
+UPDATE SET version=EXCLUDED.version, width=EXCLUDED.width, tiles=EXCLUDED.tiles, tileset_id=EXCLUDED.tileset_id;
 
 INSERT INTO exit (id, direction, location_map_id, location_x, location_y, destination_map_id, destination_x, destination_y)
 VALUES ('f214b43f-188c-44a5-b2dc-2959cc2429aa', 'east', '5231e20f-0658-4685-9396-6e69ebfb2c3b', 2, 0, 'a70bdd6f-b2a3-451e-aed2-90d1fe37f0dd', 0, 4) ON CONFLICT (id) DO

--- a/src/main/resources/db/migration/V0025__game_map_version.sql
+++ b/src/main/resources/db/migration/V0025__game_map_version.sql
@@ -1,3 +1,14 @@
+-- Add version column
 ALTER TABLE game_map ADD COLUMN version INTEGER;
 
+-- Set every existing map to the immutable version
+-- They're all inventories and two handmade zones, so they shouldn't get updated
+-- when we wire that functionality in
 UPDATE game_map SET version = -1;
+
+-- Now that none of the versions are null we can add the NOT NULL constraint
+-- to prevent any new maps without versions from getting in
+ALTER TABLE game_map ALTER COLUMN version SET NOT NULL;
+
+-- Fix any inventory maps that are already in the game with the wrong tile number
+UPDATE game_map SET tiles = decode('00', 'hex') WHERE tileset_id = '429a3d68-7658-47b0-bba7-8a1d52fb097e';

--- a/src/main/resources/db/migration/V0025__game_map_version.sql
+++ b/src/main/resources/db/migration/V0025__game_map_version.sql
@@ -1,0 +1,3 @@
+ALTER TABLE game_map ADD COLUMN version INTEGER;
+
+UPDATE game_map SET version = -1;

--- a/src/test/java/com/agonyengine/model/actor/GameMapTest.java
+++ b/src/test/java/com/agonyengine/model/actor/GameMapTest.java
@@ -52,6 +52,15 @@ public class GameMapTest {
     }
 
     @Test
+    public void testVersion() {
+        int version = 5;
+
+        map.setVersion(version);
+
+        assertEquals(version, map.getVersion());
+    }
+
+    @Test
     public void testWidth() {
         assertEquals(3, map.getWidth());
 

--- a/src/test/java/com/agonyengine/model/generator/MapGeneratorTest.java
+++ b/src/test/java/com/agonyengine/model/generator/MapGeneratorTest.java
@@ -12,17 +12,17 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import static com.agonyengine.model.actor.GameMap.CURRENT_MAP_VERSION;
+import static com.agonyengine.model.actor.GameMap.NO_UPDATE_VERSION;
 import static com.agonyengine.model.actor.TileFlag.IMPASSABLE;
 import static com.agonyengine.model.actor.TileFlag.WILDERNESS;
 import static com.agonyengine.model.generator.MapGenerator.MAP_MIN_WIDTH;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,7 +38,8 @@ public class MapGeneratorTest {
     @Mock
     private Tileset tileset;
 
-    private List<Tile> fakeTiles;
+    private List<Tile> wilderness;
+    private Tile impassable;
 
     private MapGenerator mapGenerator;
 
@@ -46,7 +47,14 @@ public class MapGeneratorTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        fakeTiles = generateTiles();
+        List<Tile> fakeTiles = generateTiles();
+        wilderness = fakeTiles.stream()
+            .filter(tile -> tile.getFlags().contains(WILDERNESS))
+            .collect(Collectors.toList());
+        impassable = fakeTiles.stream()
+            .filter(tile -> tile.getFlags().contains(IMPASSABLE))
+            .collect(Collectors.toList())
+        .get(0);
 
         when(gameMapRepository.save(any(GameMap.class))).thenAnswer(i -> {
             GameMap map = i.getArgument(0);
@@ -62,45 +70,138 @@ public class MapGeneratorTest {
     }
 
     @Test
-    public void testGeneratorTouchesAllTiles() {
+    public void testGenerateMap() {
         GameMap map = mapGenerator.generateMap(tileset);
+
+        assertNotNull(map.getId());
+        assertEquals(CURRENT_MAP_VERSION, map.getVersion());
+
+        for (int x = 0; x < map.getWidth(); x++) {
+            for (int y = 0; y < map.getWidth(); y++) {
+                assertNotNull(map.getTile(x, y));
+            }
+        }
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testUpdateMapWillNotUpdateCurrentVersion() {
+        GameMap map = spy(mapGenerator.createBlankMap(tileset));
+
+        map.setVersion(CURRENT_MAP_VERSION);
+
+        GameMap savedMap = mapGenerator.updateMap(map);
+
+        assertEquals(map, savedMap);
+        assertEquals(CURRENT_MAP_VERSION, map.getVersion());
+        verify(map, never()).setTile(anyInt(), anyInt(), anyByte());
+        verify(gameMapRepository, never()).save(any(GameMap.class));
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testUpdateMapWillNotUpdateNoUpdateVersion() {
+        GameMap map = spy(mapGenerator.createBlankMap(tileset));
+
+        map.setVersion(NO_UPDATE_VERSION);
+
+        GameMap savedMap = mapGenerator.updateMap(map);
+
+        assertEquals(map, savedMap);
+        assertEquals(NO_UPDATE_VERSION, map.getVersion());
+        verify(map, never()).setTile(anyInt(), anyInt(), anyByte());
+        verify(gameMapRepository, never()).save(any(GameMap.class));
+    }
+
+    @Test
+    public void testUpdateMap() {
+        GameMap map = spy(mapGenerator.createBlankMap(tileset));
+
+        map.setVersion(CURRENT_MAP_VERSION - 1);
+
+        GameMap savedMap = mapGenerator.updateMap(map);
+
+        assertEquals(map, savedMap);
+        assertEquals(CURRENT_MAP_VERSION, map.getVersion());
+        verify(map, atLeastOnce()).setTile(anyInt(), anyInt(), anyByte());
+        verify(gameMapRepository).save(eq(map));
+    }
+
+    @Test
+    public void testFloodFillTouchesAllTiles() {
+        GameMap map = mapGenerator.createBlankMap(tileset);
+
+        mapGenerator.floodFill(map, wilderness);
 
         for (int x = 0; x < map.getWidth(); x++) {
             for (int y = 0; y < map.getWidth(); y++) {
                 assertTrue(map.getTile(x, y).getIndex() != 0);
             }
         }
-
-        verify(gameMapRepository).save(eq(map));
     }
 
     @Test
-    public void testMapWidthIsWithinBounds() {
+    public void testFloodFillIsWithinBounds() {
         final Random mockRandom = mock(Random.class);
         final int mapAdditionalWidth = 7;
 
         when(mockRandom.nextInt(anyInt())).thenReturn(mapAdditionalWidth);
 
         MapGenerator mapGenerator = new MapGenerator(gameMapRepository, tileRepository, mockRandom);
-        GameMap map = mapGenerator.generateMap(tileset);
+        GameMap map = mapGenerator.createBlankMap(tileset);
 
         assertEquals(MAP_MIN_WIDTH + mapAdditionalWidth, map.getWidth());
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
-    public void testWildernessTileShuffle() {
-        GameMap map = mapGenerator.generateMap(tileset);
+    public void testFloodFillTileShuffle() {
+        GameMap map = mapGenerator.createBlankMap(tileset);
 
-        fakeTiles.stream()
-            .filter(tile -> tile.getFlags().contains(WILDERNESS))
-            .forEach(tile -> verify(tile, atLeastOnce()).getIndex());
+        mapGenerator.floodFill(map, wilderness);
 
-        fakeTiles.stream()
-            .filter(tile -> !tile.getFlags().contains(WILDERNESS))
-            .forEach(tile -> verify(tile, never()).getIndex());
+        wilderness.forEach(tile -> verify(tile, atLeastOnce()).getIndex());
+    }
 
-        verify(gameMapRepository).save(eq(map));
+    @Test
+    public void testSquare() {
+        GameMap map = mapGenerator.createBlankMap(tileset);
+
+        mapGenerator.drawSquare(map, impassable, 5, 5, 2);
+
+        int count = 0;
+
+        for (int x = 3; x <= 7; x++) {
+            for (int y = 3; y <= 7; y++) {
+                assertTrue(map.getTile(x, y).getFlags().contains(IMPASSABLE));
+                count++;
+            }
+        }
+
+        assertEquals(25, count);
+    }
+
+    @Test
+    public void testCircle() {
+        GameMap map = mapGenerator.createBlankMap(tileset);
+
+        mapGenerator.floodFill(map, wilderness);
+        mapGenerator.drawCircle(map, impassable, 5, 5, 2);
+
+        int count = 0;
+
+        for (int x = 3; x <= 7; x++) {
+            for (int y = 3; y <= 7; y++) {
+                if (mapGenerator.distance(5, 5, x, y) <= 2) {
+                    assertTrue(map.getTile(x, y).getFlags().contains(IMPASSABLE));
+                    count++;
+                } else {
+                    assertFalse(map.getTile(x, y).getFlags().contains(IMPASSABLE));
+                }
+            }
+        }
+
+        assertEquals(13, count);
     }
 
     private List<Tile> generateTiles() {

--- a/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
+++ b/src/test/java/com/agonyengine/resource/WebSocketResourceTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.agonyengine.model.actor.GameMap.NO_UPDATE_VERSION;
 import static com.agonyengine.resource.WebSocketResource.SPRING_SESSION_ID_KEY;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -292,6 +293,10 @@ public class WebSocketResourceTest {
 
         GameMap inventory = gameMapCaptor.getValue();
 
+        assertEquals(NO_UPDATE_VERSION, inventory.getVersion());
+        assertEquals(1, inventory.getWidth());
+        assertEquals(tileset, inventory.getTileset());
+        assertEquals((byte)0x00, inventory.getTiles()[0]);
         assertEquals(tile, inventory.getTile(0, 0));
 
         assertTrue(output.getOutput().stream()


### PR DESCRIPTION
This will allow the creation of new maps using the full algorithm and uplifting existing maps from the previous version via an update method. It also allows maps which shouldn't get updated because they were hand-rolled or aren't standard maps (e.g. inventory maps).

Closes #146