### PR TITLE
Update OWASP dependency checker to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ out/
 # Gradle
 .gradle/
 build/
+.gradletasknamecache
 
 # Codeship
 codeship.aes

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'org.owasp.dependencycheck'
 apply plugin: 'org.kordamp.gradle.stats'
 
 sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 buildscript {
     repositories {
@@ -21,7 +22,7 @@ buildscript {
         classpath group: 'org.springframework.boot', name: 'spring-boot-gradle-plugin', version: '2.0.3.RELEASE'
         classpath group: 'se.transmode.gradle', name: 'gradle-docker', version: '1.2'
         classpath group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: '1.3.0'
-        classpath group: 'org.owasp', name: 'dependency-check-gradle', version: '3.2.1'
+        classpath group: 'org.owasp', name: 'dependency-check-gradle', version: '3.3.2'
         classpath group: 'org.kordamp.gradle', name: 'stats-gradle-plugin', version: '0.2.2'
     }
 }
@@ -37,7 +38,7 @@ configurations.compile {
 dependencies {
     compile group: 'javax.inject', name: 'javax.inject', version: '1'
 
-    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.2'
+    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.5'
     compile group: 'org.flywaydb', name: 'flyway-core', version: '5.0.7'
 
     compile group: 'org.springframework.boot', name: 'spring-boot-starter'

--- a/codequality/cve-suppressions.xml
+++ b/codequality/cve-suppressions.xml
@@ -1,3 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: postgresql-42.2.5.jar
+   ]]></notes>
+        <gav regex="true">^org\.postgresql:postgresql:.*$</gav>
+        <cve>CVE-2016-7048</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-session-jdbc-2.0.4.RELEASE.jar
+   ]]></notes>
+        <gav regex="true">^org\.springframework\.session:spring-session-jdbc:.*$</gav>
+        <cve>CVE-2016-9878</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-session-jdbc-2.0.4.RELEASE.jar
+   ]]></notes>
+        <gav regex="true">^org\.springframework\.session:spring-session-jdbc:.*$</gav>
+        <cve>CVE-2018-1270</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-session-jdbc-2.0.4.RELEASE.jar
+   ]]></notes>
+        <gav regex="true">^org\.springframework\.session:spring-session-jdbc:.*$</gav>
+        <cve>CVE-2018-1271</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-session-jdbc-2.0.4.RELEASE.jar
+   ]]></notes>
+        <gav regex="true">^org\.springframework\.session:spring-session-jdbc:.*$</gav>
+        <cve>CVE-2018-1272</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
* Suppressed postgres CVE because it applies to the interactive installer for the database, not the JDBC client.
* Suppressed Spring CVEs because they refer to Spring 2.x and we're on 5.x.
* Closes #82 