### PR TITLE
Relocate players to the center of the map

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.agonyengine'
-version '0.17.0-SNAPSHOT'
+version '0.17.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/src/main/resources/db/migration/V0032__relocate_players.sql
+++ b/src/main/resources/db/migration/V0032__relocate_players.sql
@@ -1,0 +1,6 @@
+-- Take players out of any rooms they are in, forcing them back to the center of the map.
+UPDATE actor SET room_id=NULL WHERE connection_id IS NOT NULL;
+
+-- Delete all rooms that already exist and are not inventories.
+-- They will get recreated by players.
+DELETE FROM room WHERE x IS NOT NULL AND y IS NOT NULL AND z IS NOT NULL;


### PR DESCRIPTION
The game remembers where players were located, which is typically at (0, 0) or possibly negative coordinates which would be out of bounds now. This will relocate everybody to the center of the map and delete all the pre-existing rooms. I thought this was in the last PR but I had removed it for some reason.